### PR TITLE
Avoid calling onlyOwner methods in constructor

### DIFF
--- a/src/Ownable.sol
+++ b/src/Ownable.sol
@@ -31,7 +31,8 @@ contract Ownable {
      * @dev Initializes the contract setting the deployer as the initial owner.
      */
     constructor (address initialOwner) {
-        transferOwnership(initialOwner);
+        emit OwnershipTransferred(address(0), initialOwner);
+        owner = initialOwner;
     }
 
     /**

--- a/src/Shares.sol
+++ b/src/Shares.sol
@@ -77,7 +77,8 @@ contract Shares is ERC20Recoverable, Ownable {
     event SubRegisterRemoved(address contractAddress);
 
     constructor(address firstowner, string memory _symbol, string memory _name, string memory _terms) ERC20(0) Ownable(firstowner) {
-        setName(_symbol, _name);
+        symbol = _symbol;
+        name = _name;
         terms = _terms;
     }
 


### PR DESCRIPTION
Doing the same task directly.
! setting the name in constructor doesn't emit an event anymore