### PR TITLE
SharesFactory update

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,1 @@
+artifacts

--- a/src/Shares.sol
+++ b/src/Shares.sol
@@ -77,8 +77,7 @@ contract Shares is ERC20Recoverable, Ownable {
     event SubRegisterRemoved(address contractAddress);
 
     constructor(address firstowner, string memory _symbol, string memory _name, string memory _terms) ERC20(0) Ownable(firstowner) {
-        symbol = _symbol;
-        name = _name;
+        setName(_symbol, _name);
         terms = _terms;
     }
 

--- a/src/SharesFactory.sol
+++ b/src/SharesFactory.sol
@@ -10,6 +10,8 @@ import "./Shares.sol";
 contract SharesFactory {
 
   function create(bytes32 salt, string memory ticker, string memory name, string memory terms) public returns (address) {
-    return address(new Shares{salt: salt}(msg.sender, ticker, name, terms));
+    Shares shares = new Shares{salt: salt}(address(this), ticker, name, terms);
+    shares.transferOwnership(msg.sender);
+    return address(shares);
   }
 }


### PR DESCRIPTION
- calling Shares constructor with address(this) as initial owner, then transferring ownership.
- Reverted Shares constructor to use setName(symbol, name)
- Added gitignore for Remix IDE artifacts folder