### PR TITLE
Uniswap v3

### DIFF
--- a/src/IUniswapV3.sol
+++ b/src/IUniswapV3.sol
@@ -1,0 +1,32 @@
+// SPDX-License-Identifier: MIT
+// https://github.com/Uniswap/uniswap-v3-periphery/blob/main/contracts/interfaces/IQuoter.sol
+pragma solidity >=0.8;
+
+interface IQuoter {
+    function quoteExactOutputSingle(
+        address tokenIn,
+        address tokenOut,
+        uint24 fee,
+        uint256 amountOut,
+        uint160 sqrtPriceLimitX96
+    ) external returns (uint256 amountIn);
+    
+    function WETH9() external view returns (address);
+}
+
+interface ISwapRouter {
+    struct ExactOutputSingleParams {
+        address tokenIn;
+        address tokenOut;
+        uint24 fee;
+        address recipient;
+        uint256 deadline;
+        uint256 amountOut;
+        uint256 amountInMaximum;
+        uint160 sqrtPriceLimitX96;
+    }
+
+    function exactOutputSingle(ExactOutputSingleParams calldata params) external payable returns (uint256 amountIn);
+    
+    function refundETH() external payable;
+}

--- a/src/PaymentHub.sol
+++ b/src/PaymentHub.sol
@@ -29,7 +29,6 @@ pragma solidity >=0.8;
 
 import "./Address.sol";
 import "./IERC20.sol";
-import "./IUniswapV2.sol";
 import "./IUniswapV3.sol";
 import "./ITokenReceiver.sol";
 import "./Ownable.sol";
@@ -42,24 +41,14 @@ import "./Ownable.sol";
  */
 contract PaymentHub {
 
-    // immutable variables get integrated into the bytecode at deployment time, constants at compile time
-    // Unlike normal variables, changing their values changes the codehash of a contract!
-    // IUniswapV2 constant uniswap = IUniswapV2(0x7a250d5630B4cF539739dF2C5dAcb4c659F2488D);
-    IQuoter constant uniswapQuoter = IQuoter(0xb27308f9F90D607463bb33eA1BeBb41C27CE5AB6);
-    ISwapRouter constant uniswapRouter = ISwapRouter(0xE592427A0AEce92De3Edee1F18E0157C05861564);
     address public immutable weth; 
     address public immutable currency;
+    IQuoter constant uniswapQuoter = IQuoter(0xb27308f9F90D607463bb33eA1BeBb41C27CE5AB6);
+    ISwapRouter constant uniswapRouter = ISwapRouter(0xE592427A0AEce92De3Edee1F18E0157C05861564);
 
     constructor(address currency_) {
         currency = currency_;
         weth = uniswapQuoter.WETH9();
-    }
-
-    function getPath() private view returns (address[] memory) {
-        address[] memory path = new address[](2);
-        path[0] = address(weth);
-        path[1] = address(currency);
-        return path;
     }
 
     function getPriceInEther(uint256 amountOfXCHF) public returns (uint256) {
@@ -111,12 +100,6 @@ contract PaymentHub {
         }
     }
 
-/*     function approveAndCall(address token, uint256 amount, address target, bytes calldata data, uint256 weiValue) public returns (bytes memory) {
-        require((IERC20(token)).transferFrom(msg.sender, address(this), amount));
-        require((IERC20(token)).approve(target, amount));
-        return Address.functionCallWithValue(target, data, weiValue);
-    } */
-
     // Allows to make a payment from the sender to an address given an allowance to this contract
     // Equivalent to xchf.transferAndCall(recipient, xchfamount)
     function payAndNotify(address recipient, uint256 xchfamount, bytes calldata ref) public {
@@ -140,5 +123,4 @@ contract PaymentHub {
     function recover(address ercAddress, address to, uint256 amount) public {
         IERC20(ercAddress).transfer(to, amount);
     }
-
 }

--- a/src/PaymentHub.sol
+++ b/src/PaymentHub.sol
@@ -62,10 +62,8 @@ contract PaymentHub {
         return path;
     }
 
-    function getPriceInEther(uint256 amountOfXCHF) public payable returns (uint256) {
+    function getPriceInEther(uint256 amountOfXCHF) public returns (uint256) {
         return uniswapQuoter.quoteExactOutputSingle(weth, currency, 3000, amountOfXCHF, 0);
-
-        // return uniswap.getAmountsIn(amountOfXCHF, getPath())[0];
     }
 
     /**
@@ -77,7 +75,7 @@ contract PaymentHub {
             currency,
             3000,
             recipient,
-            block.timestamp + 15,
+            block.timestamp,
             xchfamount,
             msg.value,
             0
@@ -92,13 +90,6 @@ contract PaymentHub {
             uniswapRouter.refundETH();
             payable(msg.sender).transfer(address(this).balance); // return change
         }
-
-        /*
-        uniswap.swapETHForExactTokens{value: msg.value}(xchfamount, getPath(), recipient, block.timestamp);
-        if (address(this).balance > 0){
-            payable(msg.sender).transfer(address(this).balance); // return change
-        }
-        */
     }
 
     function multiPay(address[] calldata recipients, uint256[] calldata amounts) public {


### PR DESCRIPTION
Tests pass.
We would want to increase liquidity in the v3 pool before actually deploying to production.
You can migrate existing positions here: https://app.uniswap.org/#/migrate/v2
There will be some markets (Quitt, GCS) which will still use v2 until we change the PaymentHub. So we either need to leave some liquidity on v2 for some time, or update those simultaneously.