### PR TITLE
fix name and symbol double bug

### DIFF
--- a/src/ERC20/extensions/ERC20Named.sol
+++ b/src/ERC20/extensions/ERC20Named.sol
@@ -11,7 +11,7 @@ contract ERC20Named is ERC20Flaggable, Ownable {
     string public override symbol;
 
     constructor(address _admin, string memory _name , string memory _symbol, uint8 _decimals) ERC20Flaggable(_decimals) Ownable(_admin) {
-        setNameInternal(_name, _symbol);
+        setNameInternal(_symbol, _name);
     }
 
     function setName(string memory _symbol, string memory _name) external onlyOwner {

--- a/src/shares/Shares.sol
+++ b/src/shares/Shares.sol
@@ -66,8 +66,6 @@ contract Shares is ERC20Recoverable, ERC20Named {
         ERC20Named(_owner, _name, _symbol, 0) 
         ERC20Recoverable(_recoveryHub)
     {
-        symbol = _symbol;
-        name = _name;
         totalShares = _totalShares;
         terms = _terms;
     }

--- a/src/shares/allowlist/AllowlistShares.sol
+++ b/src/shares/allowlist/AllowlistShares.sol
@@ -29,7 +29,6 @@ pragma solidity ^0.8.0;
 
 import "../../recovery/ERC20Recoverable.sol";
 import "./ERC20Allowlistable.sol";
-import "../../ERC20/extensions/ERC20Named.sol";
 import "../Shares.sol";
 
 contract AllowlistShares is Shares, ERC20Allowlistable {


### PR DESCRIPTION
Event emitted name and symbol in wrong order.
- fixed ERC20Named.sol constructor to call setNameInternal in right order
- fixed Shares.sol to don't override name and symbol
- removed unused import of ER20Named from AllowlistShares (since it Inherits from Shares)


test passed before as overriding in Shares hide the error in ERC20Named