### PR TITLE
A couple of gas optimisations :-D

### DIFF
--- a/src/ERC20/ERC20Allowlistable.sol
+++ b/src/ERC20/ERC20Allowlistable.sol
@@ -90,8 +90,12 @@ abstract contract ERC20Allowlistable is ERC20Flaggable, Ownable {
   }
 
   function setType(address[] calldata addressesToAdd, uint8 value) public onlyOwner {
-    for (uint i=0; i<addressesToAdd.length; i++){
+    uint len = addressesToAdd.length;
+    for (uint i; i < len; ) {
       setType(addressesToAdd, value);
+      unchecked {
+        i++;
+      }
     }
   }
 

--- a/src/ERC20/ERC20Flaggable.sol
+++ b/src/ERC20/ERC20Flaggable.sol
@@ -42,7 +42,7 @@ import "./IERC677Receiver.sol";
 abstract contract ERC20Flaggable is IERC20 {
 
     // as Documented in /doc/infiniteallowance.md
-    uint256 constant private INFINITE_ALLOWANCE = 2**255;
+    uint256 constant private INFINITE_ALLOWANCE = 1 << 255;
 
     uint256 private constant FLAGGING_MASK = 0xFFFFFFFF00000000000000000000000000000000000000000000000000000000;
 

--- a/src/brokerbot/Brokerbot.sol
+++ b/src/brokerbot/Brokerbot.sol
@@ -147,14 +147,22 @@ contract Brokerbot is IBrokerbot, Ownable {
     }
 
     function notifyTrades(address[] calldata buyers, uint256[] calldata shares, bytes[] calldata ref) external onlyOwner {
-        for (uint i = 0; i < buyers.length; i++) {
+        uint len = buyers.length;
+        for (uint i; i < len; ) {
             notifyTraded(buyers[i], shares[i], ref[i]);
+            unchecked {
+                i++;
+            }
         }
     }
 
     function notifyTradesAndTransfer(address[] calldata buyers, uint256[] calldata shares, bytes[] calldata ref) external onlyOwner {
-        for (uint i = 0; i < buyers.length; i++) {
+        uint len = buyers.length;
+        for (uint i; i < len; ) {
             notifyTradeAndTransfer(buyers[i], shares[i], ref[i]);
+            unchecked {
+                i++;
+            }
         }
     }
 
@@ -232,7 +240,7 @@ contract Brokerbot is IBrokerbot, Ownable {
 
     function getShares(uint256 money) public view returns (uint256) {
         uint256 currentPrice = getPrice();
-        uint256 min = 0;
+        uint256 min;
         uint256 max = money / currentPrice;
         while (min < max){
             uint256 middle = (min + max)/2;

--- a/src/brokerbot/PaymentHub.sol
+++ b/src/brokerbot/PaymentHub.sol
@@ -179,8 +179,12 @@ contract PaymentHub {
     }
 
     function multiPay(IERC20 token, address[] calldata recipients, uint256[] calldata amounts) public {
-        for (uint i=0; i<recipients.length; i++) {
+        uint len = recipients.length;
+        for (uint i; i < len; ) {
             require(IERC20(token).transferFrom(msg.sender, recipients[i], amounts[i]));
+            unchecked {
+                i++;
+            }
         }
     }
 
@@ -188,8 +192,12 @@ contract PaymentHub {
      * Can (at least in theory) save some gas as the sender balance only is touched in one transaction.
      */
     function multiPayAndNotify(IERC20 token, address[] calldata recipients, uint256[] calldata amounts, bytes calldata ref) external {
-        for (uint i=0; i<recipients.length; i++) {
+        uint len = recipients.length;
+        for (uint i; i < len; ) {
             payAndNotify(token, recipients[i], amounts[i], ref);
+            unchecked {
+                i++;
+            }
         }
     }
 

--- a/src/multisig/RLPEncode.sol
+++ b/src/multisig/RLPEncode.sol
@@ -105,14 +105,17 @@ library RLPEncode {
      * @return The flattened byte string.
      */
     function flatten(bytes[] memory _list) private pure returns (bytes memory) {
-        if (_list.length == 0) {
+        uint length = _list.length;
+        if (length == 0) {
             return new bytes(0);
         }
 
         uint len;
-        uint i;
-        for (i = 0; i < _list.length; i++) {
+        for (uint i; i < length; i++) {
             len += _list[i].length;
+            unchecked {
+                i++;
+            }
         }
 
         bytes memory flattened = new bytes(len);
@@ -120,7 +123,7 @@ library RLPEncode {
         // solhint-disable-next-line no-inline-assembly
         assembly { flattenedPtr := add(flattened, 0x20) }
 
-        for(i = 0; i < _list.length; i++) {
+        for(uint i; i < length; ) {
             bytes memory item = _list[i];
             
             uint listPtr;
@@ -129,6 +132,10 @@ library RLPEncode {
 
             memcpy(flattenedPtr, listPtr, item.length);
             flattenedPtr += item.length;
+
+            unchecked {
+                i++;
+            }
         }
 
         return flattened;


### PR DESCRIPTION
I was reading today through your code and I thought I propose a couple of code changes in order to save some annoying gas.

## Changes

### No Need to Initialise Variables with Default Value
If a variable is not set/initialised, it is assumed to have the default value (`0`, `false`, `0x0` etc. depending on the [data type](https://docs.soliditylang.org/en/latest/control-structures.html#scoping-and-declarations)). If you explicitly initialise it with its default value, you are just wasting gas.

### Cache Array Length Outside of Loop
Caching the array length outside a loop saves reading it on each iteration, as long as the array's length is not changed during the loop.

### Use Shift Right/Left Instead of Division/Multiplication if Possible
A division/multiplication by any number `x` being a power of 2 can be calculated by shifting `log2(x)` to the right/left:
- `x << y` is equivalent to the mathematical expression `x * 2**y`.
- `x >> y` is equivalent to the mathematical expression `x / 2**y`, rounded towards negative infinity.

While the `DIV` opcode uses 5 gas, the `SHR` opcode only uses 3 gas. Furthermore, Solidity's division operation also includes a division-by-0 prevention which is bypassed using shifting.

### Unchecked Loop Increments
Consider the following generic for loop:
```solidity
for (uint256 i = 0; i < length; i++) {
    // do something that doesn't change the value of i
}
```

In this example, the for loop post condition, i.e., `i++` involves checked arithmetic, which is not required. This is because the value of `i` is always strictly less than `length <= 2**256 - 1`. Therefore, the theoretical maximum value of `i` to enter the for-loop body is `2**256 - 2`. This means that the `i++` in the for loop can never overflow. Regardless, the overflow checks are performed by the compiler.

Unfortunately, the Solidity optimiser is not smart enough to detect this and remove the checks. One can manually do this by:

**Alternative 1:**
```solidity
for (uint256 i = 0; i < length; i = _uncheckedInc(i)) {
    // do something that doesn't change the value of i
}

function _uncheckedInc(uint256 i) private pure returns (uint256) {
    unchecked {
        return i + 1;
    }
}
```
> Note that it's important that the call to `_uncheckedInc` is inlined. This is only possible for Solidity versions starting from `0.8.2`. => That's why I used Alternative 2 in your code.

**Alternative 2:**
```solidity
for (uint256 i = 0; i < length; ) {
    // do something that doesn't change the value of i
    unchecked {
        i++;
    }
}
```

I hope I covered everything properly otherwise let me know :-D 