### PR TITLE
Uniswap V3 routing tests for contract PaymentHub, added fixed routes

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -18,3 +18,5 @@ node_modules
 # Sensitive Files
 KEYS.ts
 /.deps
+
+.DS_Store

--- a/KEYS_TEMPLATE.ts
+++ b/KEYS_TEMPLATE.ts
@@ -6,6 +6,7 @@ const KEYS_TEMPLATE = {
         optimism: "amount marine slide ugly weather pet couch muscle brain energy rare obscure",
         polygon: "amount marine slide ugly weather pet couch muscle brain energy rare obscure",
         base: "amount marine slide ugly weather pet couch muscle brain energy rare obscure",
+        sepolia: "amount marine slide ugly weather pet couch muscle brain energy rare obscure"
     },
 
     // Etherscan Keys by Network
@@ -14,13 +15,15 @@ const KEYS_TEMPLATE = {
         optimism: "0x9186004a8121c27c9bdd465eab487e32bb8b9d0f3906305561e3ee086460d338",
         polygon: "0x9186004a8121c27c9bdd465eab487e32bb8b9d0f3906305561e3ee086460d338",
         base: "0x9186004a8121c27c9bdd465eab487e32bb8b9d0f3906305561e3ee086460d338",
+        sepolia: "0x9186004a8121c27c9bdd465eab487e32bb8b9d0f3906305561e3ee086460d338"
     },
 
     alchemy: {
         mainnet: "https://eth-mainnet.g.alchemy.com/v2/demo",
         optimism: "https://opt-mainnet.g.alchemy.com/v2/demo",
         polygon: "https://polygon-mainnet.g.alchemy.com/v2/demo",
-        base: "https://base-mainnet.g.alchemy.com/v2/demo"
+        base: "https://base-mainnet.g.alchemy.com/v2/demo",
+        sepolia: "https://sepolia.g.alchemy.com/v2/demo"
     }
 }
 

--- a/contracts/investment/PaymentHub.sol
+++ b/contracts/investment/PaymentHub.sol
@@ -1,30 +1,30 @@
 /**
-* SPDX-License-Identifier: LicenseRef-Aktionariat
-*
-* MIT License with Automated License Fee Payments
-*
-* Copyright (c) 2022 Aktionariat AG (aktionariat.com)
-*
-* Permission is hereby granted to any person obtaining a copy of this software
-* and associated documentation files (the "Software"), to deal in the Software
-* without restriction, including without limitation the rights to use, copy,
-* modify, merge, publish, distribute, sublicense, and/or sell copies of the
-* Software, and to permit persons to whom the Software is furnished to do so,
-* subject to the following conditions:
-*
-* - The above copyright notice and this permission notice shall be included in
-*   all copies or substantial portions of the Software.
-* - All automated license fee payments integrated into this and related Software
-*   are preserved.
-*
-* THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
-* IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
-* FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
-* AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
-* LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
-* OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
-* SOFTWARE.
-*/
+ * SPDX-License-Identifier: LicenseRef-Aktionariat
+ *
+ * MIT License with Automated License Fee Payments
+ *
+ * Copyright (c) 2022 Aktionariat AG (aktionariat.com)
+ *
+ * Permission is hereby granted to any person obtaining a copy of this software
+ * and associated documentation files (the "Software"), to deal in the Software
+ * without restriction, including without limitation the rights to use, copy,
+ * modify, merge, publish, distribute, sublicense, and/or sell copies of the
+ * Software, and to permit persons to whom the Software is furnished to do so,
+ * subject to the following conditions:
+ *
+ * - The above copyright notice and this permission notice shall be included in
+ *   all copies or substantial portions of the Software.
+ * - All automated license fee payments integrated into this and related Software
+ *   are preserved.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
 pragma solidity >=0.8.0 <0.9.0;
 
 import "../ERC20/IERC20.sol";
@@ -33,8 +33,12 @@ import "../utils/Ownable.sol";
 import "./IDirectInvestment.sol";
 import "./IUniswapV3.sol";
 
+interface INoReturnApprove {
+    function approve(address spender, uint256 amount) external;
+}
+
 /**
- * A hub for payments, to be used with the DirectInvestment contract. 
+ * A hub for payments, to be used with the DirectInvestment contract.
  * Enables a single allowance given to this contract to be used across multiple DirectInvestment contracts.
  * Separates payment process with possible swaps from the DirectInvestment settlement logic.
  * Handles paying with the base currency of the the DirectInvestment contract, or any other ERC20 token or ETH, by giving a Uniswap v3 swap path.
@@ -42,7 +46,6 @@ import "./IUniswapV3.sol";
  */
 
 contract PaymentHub is Ownable {
-
     using SafeERC20 for IERC20;
 
     // Version History
@@ -100,9 +103,9 @@ contract PaymentHub is Ownable {
         require(amountShares > 0, PaymentHub_InvalidAmount());
 
         checkPath(directInvestment, paymentCurrency, path);
-        
+
         uint256 priceInBaseCurrency = directInvestment.getBuyPrice(amountShares);
-        
+
         paymentCurrency.safeTransferFrom(msg.sender, address(this), amountInMaximum);
         swapToBaseCurrencyAndPay(directInvestment, priceInBaseCurrency, paymentCurrency, amountInMaximum, path);
         directInvestment.processIncoming(msg.sender, amountShares, priceInBaseCurrency, ref);
@@ -112,7 +115,7 @@ contract PaymentHub is Ownable {
     /// @dev Unused ETH is refunded as WETH.
     function payFromEtherAndNotify(IDirectInvestment directInvestment, uint256 amountShares, bytes calldata path, bytes calldata ref) public payable {
         require(amountShares > 0, PaymentHub_InvalidAmount());
-        
+
         IWETH9 weth = IWETH9(uniswapV3Quoter.WETH9());
         checkPath(directInvestment, weth, path);
 
@@ -132,14 +135,13 @@ contract PaymentHub is Ownable {
 
     /// @dev Executes the exactOutput swap into `directInvestment` and refunds unused `paymentCurrency` to the caller.
     function swapToBaseCurrencyAndPay(IDirectInvestment directInvestment, uint256 amountBaseCurrency, IERC20 paymentCurrency, uint256 amountInMaximum, bytes memory path) internal {
-        ISwapRouter.ExactOutputParams memory params =
-            ISwapRouter.ExactOutputParams({
-                path: path,
-                recipient: address(directInvestment),
-                deadline: block.timestamp,
-                amountOut: amountBaseCurrency,
-                amountInMaximum: amountInMaximum
-            });
+        ISwapRouter.ExactOutputParams memory params = ISwapRouter.ExactOutputParams({
+            path: path,
+            recipient: address(directInvestment),
+            deadline: block.timestamp,
+            amountOut: amountBaseCurrency,
+            amountInMaximum: amountInMaximum
+        });
 
         uint256 amountIn = uniswapV3SwapRouter.exactOutput(params);
 
@@ -151,7 +153,7 @@ contract PaymentHub is Ownable {
     /// @notice Grant infinite Uniswap allowance for the listed payment currencies. Must be called once per new currency.
     /// @dev Permissionless; the hub holds no token balance between transactions.
     function approvePaymentCurrencies(IERC20[] calldata erc20In) external {
-        for (uint i=0; i<erc20In.length; i++) {
+        for (uint i = 0; i < erc20In.length; i++) {
             approveERC20(erc20In[i]);
         }
     }
@@ -161,6 +163,12 @@ contract PaymentHub is Ownable {
         IERC20(erc20In).approve(address(uniswapV3SwapRouter), type(uint256).max);
     }
 
+    /// @notice Grant infinite Uniswap allowance for a single payment currency.
+    /// @dev does not return boolean for USDT approve compatability
+    function silentApproveERC20(IERC20 erc20In) public {
+        INoReturnApprove(address(erc20In)).approve(address(uniswapV3SwapRouter), type(uint256).max);
+    }
+
     /// @notice Owner rescue for tokens accidentally sent to the hub.
     function withdrawToken(IERC20 tokenAddress, address to, uint256 amount) external onlyOwner {
         tokenAddress.safeTransfer(to, amount);
@@ -168,7 +176,7 @@ contract PaymentHub is Ownable {
 
     /// @notice Pay multiple recipients in one tx, e.g. for dividends. Unrelated to share purchases.
     function multiPay(IERC20 token, address[] calldata recipients, uint256[] calldata amounts) public {
-        for (uint i=0; i<recipients.length; i++) {
+        for (uint i = 0; i < recipients.length; i++) {
             IERC20(token).safeTransferFrom(msg.sender, recipients[i], amounts[i]);
         }
     }

--- a/hardhat.config.ts
+++ b/hardhat.config.ts
@@ -1,154 +1,164 @@
 import type { HardhatUserConfig } from "hardhat/config";
-import HardhatIgnitionEthersPlugin from '@nomicfoundation/hardhat-ignition-ethers'
+import HardhatIgnitionEthersPlugin from "@nomicfoundation/hardhat-ignition-ethers";
 import hardhatToolboxMochaEthers from "@nomicfoundation/hardhat-toolbox-mocha-ethers";
 import hardhatVerify from "@nomicfoundation/hardhat-verify";
 import KEYS from "./KEYS.ts";
 
 const config: HardhatUserConfig = {
-    plugins: [
-        HardhatIgnitionEthersPlugin,
-        hardhatToolboxMochaEthers,
-        hardhatVerify
-    ],
+  plugins: [
+    HardhatIgnitionEthersPlugin,
+    hardhatToolboxMochaEthers,
+    hardhatVerify,
+  ],
 
-    solidity: {
-        version: "0.8.34",
-        settings: {
-            optimizer: {
-                enabled: true,
-                runs: 200
-            },
-            evmVersion: `prague`,
-        }
-    },    
-    networks: {
-        // Real Networks
-        mainnet: {
-            type: "http",
-            chainId: 1,
-            chainType: "l1",
-            url: KEYS.alchemy.mainnet,
-            accounts: {
-                mnemonic: KEYS.mnemonics.mainnet
-            }
-        },
-        optimism: {
-            type: "http",
-            chainId: 10,
-            chainType: "op",
-            url: KEYS.alchemy.optimism,
-            accounts: {
-                mnemonic: KEYS.mnemonics.optimism
-            }
-        },
-        polygon: {
-            type: "http",
-            chainId: 137,
-            chainType: "generic",
-            url: KEYS.alchemy.polygon,
-            accounts: {
-                mnemonic: KEYS.mnemonics.polygon
-            }
-        },
-        base: {
-            type: "http",
-            chainId: 8453,
-            chainType: "op",
-            url: KEYS.alchemy.base,
-            accounts: {
-                mnemonic: KEYS.mnemonics.base
-            }
-        },
-        sepolia: {
-            type: "http",
-            chainId: 11155111,
-            chainType: "l1",
-            url: KEYS.alchemy.sepolia,
-            accounts: {
-                mnemonic: KEYS.mnemonics.sepolia
-            }
-        },
+  solidity: {
+    version: "0.8.34",
+    settings: {
+      optimizer: {
+        enabled: true,
+        runs: 200,
+      },
+      evmVersion: `prague`,
+    },
+  },
 
-        // Simulated Networks
-        default: {
-            type: "edr-simulated",
-            chainId: 1,
-            chainType: "l1",
-            forking: {
-                url: KEYS.alchemy.mainnet,
-                enabled: true
-            },
-            accounts: {
-                mnemonic: KEYS.mnemonics.mainnet
-            }
-        },
-        hardhatMainnet: {
-            type: "edr-simulated",
-            chainId: 1,
-            chainType: "l1",
-            forking: {
-                url: KEYS.alchemy.mainnet,
-                enabled: true
-            },
-            accounts: {
-                mnemonic: KEYS.mnemonics.mainnet
-            }
-        },
-        hardhatOptimism: {
-            type: "edr-simulated",
-            chainId: 10,
-            chainType: "op",
-            forking: {
-                url: KEYS.alchemy.optimism,
-                enabled: true
-            },
-            accounts: {
-                mnemonic: KEYS.mnemonics.optimism
-            }
-        },
-        hardhatPolygon: {
-            type: "edr-simulated",
-            chainId: 137,
-            chainType: "generic",
-            forking: {
-                url: KEYS.alchemy.polygon,
-                enabled: true
-            },
-            accounts: {
-                mnemonic: KEYS.mnemonics.polygon
-            }
-        },
-        hardhatBase: {
-            type: "edr-simulated",
-            chainId: 8453,
-            chainType: "op",
-            forking: {
-                url: KEYS.alchemy.base,
-                enabled: true
-            },
-            accounts: {
-                mnemonic: KEYS.mnemonics.base
-            }
-        },
+  networks: {
+    // hardhat network forking of Mainnet
+    mainnetForkAtBlock25464800: {
+      type: "edr-simulated",
+      forking: {
+        url: KEYS.alchemy.mainnet,
+        blockNumber: 25464800,
+      },
     },
 
-    ignition: {
-        strategyConfig: {
-            create2: {
-                salt: "0x39E5351E6CE3c4B19B8b0a2F5C82c511782457BE000000000000000000000dae"
-            },
-        },
+    // Real Networks
+    mainnet: {
+      type: "http",
+      chainId: 1,
+      chainType: "l1",
+      url: KEYS.alchemy.mainnet,
+      accounts: {
+        mnemonic: KEYS.mnemonics.mainnet,
+      },
     },
-    
-    verify: {
-        // With Etherscan V2, a single API key works for multiple networks
-        etherscan: {
-            apiKey: KEYS.etherscan.mainnet
-        },
-        blockscout: {
-            enabled: true,
-        },
-    }
+    optimism: {
+      type: "http",
+      chainId: 10,
+      chainType: "op",
+      url: KEYS.alchemy.optimism,
+      accounts: {
+        mnemonic: KEYS.mnemonics.optimism,
+      },
+    },
+    polygon: {
+      type: "http",
+      chainId: 137,
+      chainType: "generic",
+      url: KEYS.alchemy.polygon,
+      accounts: {
+        mnemonic: KEYS.mnemonics.polygon,
+      },
+    },
+    base: {
+      type: "http",
+      chainId: 8453,
+      chainType: "op",
+      url: KEYS.alchemy.base,
+      accounts: {
+        mnemonic: KEYS.mnemonics.base,
+      },
+    },
+    sepolia: {
+      type: "http",
+      chainId: 11155111,
+      chainType: "l1",
+      url: KEYS.alchemy.sepolia,
+      accounts: {
+        mnemonic: KEYS.mnemonics.sepolia,
+      },
+    },
+
+    // Simulated Networks
+    default: {
+      type: "edr-simulated",
+      chainId: 1,
+      chainType: "l1",
+      forking: {
+        url: KEYS.alchemy.mainnet,
+        enabled: true,
+      },
+      accounts: {
+        mnemonic: KEYS.mnemonics.mainnet,
+      },
+    },
+    hardhatMainnet: {
+      type: "edr-simulated",
+      chainId: 1,
+      chainType: "l1",
+      forking: {
+        url: KEYS.alchemy.mainnet,
+        enabled: true,
+      },
+      accounts: {
+        mnemonic: KEYS.mnemonics.mainnet,
+      },
+    },
+    hardhatOptimism: {
+      type: "edr-simulated",
+      chainId: 10,
+      chainType: "op",
+      forking: {
+        url: KEYS.alchemy.optimism,
+        enabled: true,
+      },
+      accounts: {
+        mnemonic: KEYS.mnemonics.optimism,
+      },
+    },
+    hardhatPolygon: {
+      type: "edr-simulated",
+      chainId: 137,
+      chainType: "generic",
+      forking: {
+        url: KEYS.alchemy.polygon,
+        enabled: true,
+      },
+      accounts: {
+        mnemonic: KEYS.mnemonics.polygon,
+      },
+    },
+    hardhatBase: {
+      type: "edr-simulated",
+      chainId: 8453,
+      chainType: "op",
+      forking: {
+        url: KEYS.alchemy.base,
+        enabled: true,
+      },
+      accounts: {
+        mnemonic: KEYS.mnemonics.base,
+      },
+    },
+  },
+
+  ignition: {
+    strategyConfig: {
+      create2: {
+        salt: "0x39E5351E6CE3c4B19B8b0a2F5C82c511782457BE000000000000000000000dae",
+      },
+    },
+  },
+
+  verify: {
+    // With Etherscan V2, a single API key works for multiple networks
+    etherscan: {
+      apiKey: KEYS.etherscan.mainnet,
+    },
+    blockscout: {
+      enabled: true,
+    },
+  },
 };
 
 export default config;

--- a/package-lock.json
+++ b/package-lock.json
@@ -12,6 +12,7 @@
         "@chainlink/contracts": "^1.5.0",
         "@chainlink/contracts-ccip": "^1.6.3",
         "@openzeppelin/contracts": "^5.4.0",
+        "@uniswap/v3-core": "^1.0.1",
         "ethers": "^6.15.0"
       },
       "devDependencies": {
@@ -1998,28 +1999,28 @@
       }
     },
     "node_modules/@nomicfoundation/edr": {
-      "version": "0.12.0-next.14",
-      "resolved": "https://registry.npmjs.org/@nomicfoundation/edr/-/edr-0.12.0-next.14.tgz",
-      "integrity": "sha512-MGHY2x7JaNdkqlQxFBYoM7Miw2EqsQrI3ReVZMwLP5mULSRTAOnt3hCw6cnjXxGi991HnejNAedJofke6OdqqA==",
+      "version": "0.12.1",
+      "resolved": "https://registry.npmjs.org/@nomicfoundation/edr/-/edr-0.12.1.tgz",
+      "integrity": "sha512-1U8C+kiVMIbVkOW+Sa7sUm9glSaB5cMe7UJ9wCOHFPpBBUQgStgrgAOWOahRL0vKRUjHUpuQpg47cRcUSdmW/A==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@nomicfoundation/edr-darwin-arm64": "0.12.0-next.14",
-        "@nomicfoundation/edr-darwin-x64": "0.12.0-next.14",
-        "@nomicfoundation/edr-linux-arm64-gnu": "0.12.0-next.14",
-        "@nomicfoundation/edr-linux-arm64-musl": "0.12.0-next.14",
-        "@nomicfoundation/edr-linux-x64-gnu": "0.12.0-next.14",
-        "@nomicfoundation/edr-linux-x64-musl": "0.12.0-next.14",
-        "@nomicfoundation/edr-win32-x64-msvc": "0.12.0-next.14"
+        "@nomicfoundation/edr-darwin-arm64": "0.12.1",
+        "@nomicfoundation/edr-darwin-x64": "0.12.1",
+        "@nomicfoundation/edr-linux-arm64-gnu": "0.12.1",
+        "@nomicfoundation/edr-linux-arm64-musl": "0.12.1",
+        "@nomicfoundation/edr-linux-x64-gnu": "0.12.1",
+        "@nomicfoundation/edr-linux-x64-musl": "0.12.1",
+        "@nomicfoundation/edr-win32-x64-msvc": "0.12.1"
       },
       "engines": {
         "node": ">= 20"
       }
     },
     "node_modules/@nomicfoundation/edr-darwin-arm64": {
-      "version": "0.12.0-next.14",
-      "resolved": "https://registry.npmjs.org/@nomicfoundation/edr-darwin-arm64/-/edr-darwin-arm64-0.12.0-next.14.tgz",
-      "integrity": "sha512-sl0DibKSUOS7JXhUtaQ6FJUY+nk+uq5gx+Fyd9iiqs8awZPNn6KSuvV1EbWCi+yd3mrxgZ/wO8E77C1Dxj4xQA==",
+      "version": "0.12.1",
+      "resolved": "https://registry.npmjs.org/@nomicfoundation/edr-darwin-arm64/-/edr-darwin-arm64-0.12.1.tgz",
+      "integrity": "sha512-KRB7oRupR2CqGHTACDhdS/EJGLN2rft1+5UNeimbXYe9nS3usUNGjNJyIjvoxzFthqnFM3+vaDQwyIZfq/eRjw==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -2027,9 +2028,9 @@
       }
     },
     "node_modules/@nomicfoundation/edr-darwin-x64": {
-      "version": "0.12.0-next.14",
-      "resolved": "https://registry.npmjs.org/@nomicfoundation/edr-darwin-x64/-/edr-darwin-x64-0.12.0-next.14.tgz",
-      "integrity": "sha512-lfmatc1MSOaw0rDFB+ynnAGz5TWm3hSeY/+zDpPZghMODZelXm4JCqF41CQ6paLsW3X/pXcHM1HUGCUBWeoI/A==",
+      "version": "0.12.1",
+      "resolved": "https://registry.npmjs.org/@nomicfoundation/edr-darwin-x64/-/edr-darwin-x64-0.12.1.tgz",
+      "integrity": "sha512-h6J3otsX5ib1md5V/M281ZS37FC6mAH8QlxVi3YMe9wOpEOpBRkqfhQAeFCekdx+5pqNHO/STi5OyKwCd4YAfw==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -2037,9 +2038,9 @@
       }
     },
     "node_modules/@nomicfoundation/edr-linux-arm64-gnu": {
-      "version": "0.12.0-next.14",
-      "resolved": "https://registry.npmjs.org/@nomicfoundation/edr-linux-arm64-gnu/-/edr-linux-arm64-gnu-0.12.0-next.14.tgz",
-      "integrity": "sha512-sWun3PhVgat8d4lg1d5MAXSIsFlSMBzvrpMSDFNOU9hPJEclSHbHBMRcarQuGqwm/5ZBzTwCS25u78A+UATTrg==",
+      "version": "0.12.1",
+      "resolved": "https://registry.npmjs.org/@nomicfoundation/edr-linux-arm64-gnu/-/edr-linux-arm64-gnu-0.12.1.tgz",
+      "integrity": "sha512-yqJcBgusn+MQFCemVrm7VIYjqQLaFouo0DBAbApE0GHQ7MnVFmbW2d2WCEln3jZOZgY0FH0tfnQw/NfK2xo2zg==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -2047,9 +2048,9 @@
       }
     },
     "node_modules/@nomicfoundation/edr-linux-arm64-musl": {
-      "version": "0.12.0-next.14",
-      "resolved": "https://registry.npmjs.org/@nomicfoundation/edr-linux-arm64-musl/-/edr-linux-arm64-musl-0.12.0-next.14.tgz",
-      "integrity": "sha512-omWKioD8fFp7ayCeSDu2CqvG78+oYw8zdVECDwZVmE0jpszRCsTufNYflWRQnlGqH6GqjEUwq2c3yLxFgOTjFg==",
+      "version": "0.12.1",
+      "resolved": "https://registry.npmjs.org/@nomicfoundation/edr-linux-arm64-musl/-/edr-linux-arm64-musl-0.12.1.tgz",
+      "integrity": "sha512-JPkUOazqotQMvU2wsOQymxusCKyWaWdqHyxQKqwrqz81O+jOEXvMHUp20a6cRbVGOoGHx334ORj+daSGKvt5og==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -2057,9 +2058,9 @@
       }
     },
     "node_modules/@nomicfoundation/edr-linux-x64-gnu": {
-      "version": "0.12.0-next.14",
-      "resolved": "https://registry.npmjs.org/@nomicfoundation/edr-linux-x64-gnu/-/edr-linux-x64-gnu-0.12.0-next.14.tgz",
-      "integrity": "sha512-vk0s4SaC7s1wa98W24a4zqunTK/yIcSEnsSLRM/Nl+JJs6iqS8tvmnh/BbFINORMBJ065OWc10qw2Lsbu/rxtg==",
+      "version": "0.12.1",
+      "resolved": "https://registry.npmjs.org/@nomicfoundation/edr-linux-x64-gnu/-/edr-linux-x64-gnu-0.12.1.tgz",
+      "integrity": "sha512-pM3cP316WgSUUy6MW2FuWgjZuonCYULED8Mn1mIK6NfwzTKooves/KjBDzIzr7Mvht9SwF/tT0KRjHPf/9E8gg==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -2067,9 +2068,9 @@
       }
     },
     "node_modules/@nomicfoundation/edr-linux-x64-musl": {
-      "version": "0.12.0-next.14",
-      "resolved": "https://registry.npmjs.org/@nomicfoundation/edr-linux-x64-musl/-/edr-linux-x64-musl-0.12.0-next.14.tgz",
-      "integrity": "sha512-/xKQD6c2RXQBIb30iTeh/NrMdYvHs6Nd+2UXS6wxlfX7GzRPOkpVDiDGD7Sda82JI459KH67dADOD6CpX8cpHQ==",
+      "version": "0.12.1",
+      "resolved": "https://registry.npmjs.org/@nomicfoundation/edr-linux-x64-musl/-/edr-linux-x64-musl-0.12.1.tgz",
+      "integrity": "sha512-Rw7hhyk8PdZy3bBYVJrQX1M1AIBhy4vFnWPfbdY50c+ZfX/c82PYVg+B92+XaC5avMon/KiIhfB2fNLcyJy4uw==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -2077,9 +2078,9 @@
       }
     },
     "node_modules/@nomicfoundation/edr-win32-x64-msvc": {
-      "version": "0.12.0-next.14",
-      "resolved": "https://registry.npmjs.org/@nomicfoundation/edr-win32-x64-msvc/-/edr-win32-x64-msvc-0.12.0-next.14.tgz",
-      "integrity": "sha512-GZcyGdOoLWnUtfPU+6B1vUi4fwf3bouSRf3xuKFHz3p/WNhpDK+8Esq3UmOmYAZWRgFT0ZR6XUk9H2owGDTVvQ==",
+      "version": "0.12.1",
+      "resolved": "https://registry.npmjs.org/@nomicfoundation/edr-win32-x64-msvc/-/edr-win32-x64-msvc-0.12.1.tgz",
+      "integrity": "sha512-z2ILUf8P/oqG8t2tkPCpmhzSpo+LMZylLFUPGMgugHwe8OX1GyU11g0bQU8SoIwHozy7MLzTMX0NZ/14LWSN7Q==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -2087,13 +2088,13 @@
       }
     },
     "node_modules/@nomicfoundation/hardhat-errors": {
-      "version": "3.0.3",
-      "resolved": "https://registry.npmjs.org/@nomicfoundation/hardhat-errors/-/hardhat-errors-3.0.3.tgz",
-      "integrity": "sha512-qvVIyNE5yXFdwCD7G74fb3j+p5PjYSej/K2mhOuJBhxdGwzARpyoJbcDZrjkNyabytlt95iniZLHHWM9jvVXEA==",
+      "version": "3.0.16",
+      "resolved": "https://registry.npmjs.org/@nomicfoundation/hardhat-errors/-/hardhat-errors-3.0.16.tgz",
+      "integrity": "sha512-z3hxWX2vG0C0JBojKHcUjArOXftHQZ2cPnHOSReILq6/UZXuzm9WIEBDPbotH2tgjRDKBlh0+XOpJZjFhEODIw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@nomicfoundation/hardhat-utils": "^3.0.1"
+        "@nomicfoundation/hardhat-utils": "^4.1.4"
       }
     },
     "node_modules/@nomicfoundation/hardhat-ethers": {
@@ -2135,6 +2136,42 @@
         "hardhat": "^3.0.0"
       }
     },
+    "node_modules/@nomicfoundation/hardhat-ethers-chai-matchers/node_modules/@nomicfoundation/hardhat-utils": {
+      "version": "3.0.6",
+      "resolved": "https://registry.npmjs.org/@nomicfoundation/hardhat-utils/-/hardhat-utils-3.0.6.tgz",
+      "integrity": "sha512-AD/LPNdjXNFRrZcaAAewgJpdnHpPppZxo5p+x6wGMm5Hz4B3+oLf/LUzVn8qb4DDy9RE2c24l2F8vmL/w6ZuXg==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "@streamparser/json-node": "^0.0.22",
+        "debug": "^4.3.2",
+        "env-paths": "^2.2.0",
+        "ethereum-cryptography": "^2.2.1",
+        "fast-equals": "^5.4.0",
+        "json-stream-stringify": "^3.1.6",
+        "rfdc": "^1.3.1",
+        "undici": "^6.16.1"
+      }
+    },
+    "node_modules/@nomicfoundation/hardhat-ethers/node_modules/@nomicfoundation/hardhat-utils": {
+      "version": "3.0.6",
+      "resolved": "https://registry.npmjs.org/@nomicfoundation/hardhat-utils/-/hardhat-utils-3.0.6.tgz",
+      "integrity": "sha512-AD/LPNdjXNFRrZcaAAewgJpdnHpPppZxo5p+x6wGMm5Hz4B3+oLf/LUzVn8qb4DDy9RE2c24l2F8vmL/w6ZuXg==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "@streamparser/json-node": "^0.0.22",
+        "debug": "^4.3.2",
+        "env-paths": "^2.2.0",
+        "ethereum-cryptography": "^2.2.1",
+        "fast-equals": "^5.4.0",
+        "json-stream-stringify": "^3.1.6",
+        "rfdc": "^1.3.1",
+        "undici": "^6.16.1"
+      }
+    },
     "node_modules/@nomicfoundation/hardhat-ignition": {
       "version": "3.0.5",
       "resolved": "https://registry.npmjs.org/@nomicfoundation/hardhat-ignition/-/hardhat-ignition-3.0.5.tgz",
@@ -2173,6 +2210,24 @@
         "@nomicfoundation/ignition-core": "^3.0.5",
         "ethers": "^6.14.0",
         "hardhat": "^3.0.0"
+      }
+    },
+    "node_modules/@nomicfoundation/hardhat-ignition/node_modules/@nomicfoundation/hardhat-utils": {
+      "version": "3.0.6",
+      "resolved": "https://registry.npmjs.org/@nomicfoundation/hardhat-utils/-/hardhat-utils-3.0.6.tgz",
+      "integrity": "sha512-AD/LPNdjXNFRrZcaAAewgJpdnHpPppZxo5p+x6wGMm5Hz4B3+oLf/LUzVn8qb4DDy9RE2c24l2F8vmL/w6ZuXg==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "@streamparser/json-node": "^0.0.22",
+        "debug": "^4.3.2",
+        "env-paths": "^2.2.0",
+        "ethereum-cryptography": "^2.2.1",
+        "fast-equals": "^5.4.0",
+        "json-stream-stringify": "^3.1.6",
+        "rfdc": "^1.3.1",
+        "undici": "^6.16.1"
       }
     },
     "node_modules/@nomicfoundation/hardhat-ignition/node_modules/chalk": {
@@ -2224,6 +2279,24 @@
         "url": "https://paulmillr.com/funding/"
       }
     },
+    "node_modules/@nomicfoundation/hardhat-keystore/node_modules/@nomicfoundation/hardhat-utils": {
+      "version": "3.0.6",
+      "resolved": "https://registry.npmjs.org/@nomicfoundation/hardhat-utils/-/hardhat-utils-3.0.6.tgz",
+      "integrity": "sha512-AD/LPNdjXNFRrZcaAAewgJpdnHpPppZxo5p+x6wGMm5Hz4B3+oLf/LUzVn8qb4DDy9RE2c24l2F8vmL/w6ZuXg==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "@streamparser/json-node": "^0.0.22",
+        "debug": "^4.3.2",
+        "env-paths": "^2.2.0",
+        "ethereum-cryptography": "^2.2.1",
+        "fast-equals": "^5.4.0",
+        "json-stream-stringify": "^3.1.6",
+        "rfdc": "^1.3.1",
+        "undici": "^6.16.1"
+      }
+    },
     "node_modules/@nomicfoundation/hardhat-keystore/node_modules/chalk": {
       "version": "5.6.2",
       "resolved": "https://registry.npmjs.org/chalk/-/chalk-5.6.2.tgz",
@@ -2255,6 +2328,24 @@
         "zod": "^3.23.8"
       }
     },
+    "node_modules/@nomicfoundation/hardhat-mocha/node_modules/@nomicfoundation/hardhat-utils": {
+      "version": "3.0.6",
+      "resolved": "https://registry.npmjs.org/@nomicfoundation/hardhat-utils/-/hardhat-utils-3.0.6.tgz",
+      "integrity": "sha512-AD/LPNdjXNFRrZcaAAewgJpdnHpPppZxo5p+x6wGMm5Hz4B3+oLf/LUzVn8qb4DDy9RE2c24l2F8vmL/w6ZuXg==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "@streamparser/json-node": "^0.0.22",
+        "debug": "^4.3.2",
+        "env-paths": "^2.2.0",
+        "ethereum-cryptography": "^2.2.1",
+        "fast-equals": "^5.4.0",
+        "json-stream-stringify": "^3.1.6",
+        "rfdc": "^1.3.1",
+        "undici": "^6.16.1"
+      }
+    },
     "node_modules/@nomicfoundation/hardhat-network-helpers": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/@nomicfoundation/hardhat-network-helpers/-/hardhat-network-helpers-3.0.0.tgz",
@@ -2268,6 +2359,24 @@
       },
       "peerDependencies": {
         "hardhat": "^3.0.0"
+      }
+    },
+    "node_modules/@nomicfoundation/hardhat-network-helpers/node_modules/@nomicfoundation/hardhat-utils": {
+      "version": "3.0.6",
+      "resolved": "https://registry.npmjs.org/@nomicfoundation/hardhat-utils/-/hardhat-utils-3.0.6.tgz",
+      "integrity": "sha512-AD/LPNdjXNFRrZcaAAewgJpdnHpPppZxo5p+x6wGMm5Hz4B3+oLf/LUzVn8qb4DDy9RE2c24l2F8vmL/w6ZuXg==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "@streamparser/json-node": "^0.0.22",
+        "debug": "^4.3.2",
+        "env-paths": "^2.2.0",
+        "ethereum-cryptography": "^2.2.1",
+        "fast-equals": "^5.4.0",
+        "json-stream-stringify": "^3.1.6",
+        "rfdc": "^1.3.1",
+        "undici": "^6.16.1"
       }
     },
     "node_modules/@nomicfoundation/hardhat-toolbox-mocha-ethers": {
@@ -2314,22 +2423,46 @@
         "hardhat": "^3.0.0"
       }
     },
-    "node_modules/@nomicfoundation/hardhat-utils": {
-      "version": "3.0.5",
-      "resolved": "https://registry.npmjs.org/@nomicfoundation/hardhat-utils/-/hardhat-utils-3.0.5.tgz",
-      "integrity": "sha512-5zkQSuSxkwK7fQxKswJ1GGc/3AuWBSmxA7GhczTPLx28dAXQnubRU8nA48SkCkKesJq5x4TROP+XheSE2VkLUA==",
+    "node_modules/@nomicfoundation/hardhat-typechain/node_modules/@nomicfoundation/hardhat-utils": {
+      "version": "3.0.6",
+      "resolved": "https://registry.npmjs.org/@nomicfoundation/hardhat-utils/-/hardhat-utils-3.0.6.tgz",
+      "integrity": "sha512-AD/LPNdjXNFRrZcaAAewgJpdnHpPppZxo5p+x6wGMm5Hz4B3+oLf/LUzVn8qb4DDy9RE2c24l2F8vmL/w6ZuXg==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@streamparser/json-node": "^0.0.22",
         "debug": "^4.3.2",
         "env-paths": "^2.2.0",
         "ethereum-cryptography": "^2.2.1",
-        "fast-equals": "^5.0.1",
+        "fast-equals": "^5.4.0",
         "json-stream-stringify": "^3.1.6",
         "rfdc": "^1.3.1",
         "undici": "^6.16.1"
       }
+    },
+    "node_modules/@nomicfoundation/hardhat-utils": {
+      "version": "4.1.4",
+      "resolved": "https://registry.npmjs.org/@nomicfoundation/hardhat-utils/-/hardhat-utils-4.1.4.tgz",
+      "integrity": "sha512-DEAu/uIBTNkPedfTnokh6tKum/Kxr5xMlh8ZovBGqlKA8AlxP26J0PBjK73fmeUQ0sh432suWksSr5CtHVG04A==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@streamparser/json-node": "^0.0.22",
+        "env-paths": "^2.2.0",
+        "ethereum-cryptography": "^2.2.1",
+        "fast-equals": "^5.4.0",
+        "json-stream-stringify": "^3.1.6",
+        "rfdc": "^1.3.1",
+        "undici": "^6.16.1"
+      }
+    },
+    "node_modules/@nomicfoundation/hardhat-vendored": {
+      "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/@nomicfoundation/hardhat-vendored/-/hardhat-vendored-3.0.4.tgz",
+      "integrity": "sha512-RO8Otj1FvRvxJmXzkxh1vTwK/+cqSVPYLqY6RrWkmzHEEcxnAwAFsBYdW7xyTEyW/pVbSSNd2gs3aoGdGZaoNA==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/@nomicfoundation/hardhat-verify": {
       "version": "3.0.6",
@@ -2352,6 +2485,23 @@
         "hardhat": "^3.0.0"
       }
     },
+    "node_modules/@nomicfoundation/hardhat-verify/node_modules/@nomicfoundation/hardhat-utils": {
+      "version": "3.0.6",
+      "resolved": "https://registry.npmjs.org/@nomicfoundation/hardhat-utils/-/hardhat-utils-3.0.6.tgz",
+      "integrity": "sha512-AD/LPNdjXNFRrZcaAAewgJpdnHpPppZxo5p+x6wGMm5Hz4B3+oLf/LUzVn8qb4DDy9RE2c24l2F8vmL/w6ZuXg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@streamparser/json-node": "^0.0.22",
+        "debug": "^4.3.2",
+        "env-paths": "^2.2.0",
+        "ethereum-cryptography": "^2.2.1",
+        "fast-equals": "^5.4.0",
+        "json-stream-stringify": "^3.1.6",
+        "rfdc": "^1.3.1",
+        "undici": "^6.16.1"
+      }
+    },
     "node_modules/@nomicfoundation/hardhat-verify/node_modules/chalk": {
       "version": "5.6.2",
       "resolved": "https://registry.npmjs.org/chalk/-/chalk-5.6.2.tgz",
@@ -2366,14 +2516,14 @@
       }
     },
     "node_modules/@nomicfoundation/hardhat-zod-utils": {
-      "version": "3.0.1",
-      "resolved": "https://registry.npmjs.org/@nomicfoundation/hardhat-zod-utils/-/hardhat-zod-utils-3.0.1.tgz",
-      "integrity": "sha512-I6/pyYiS9p2lLkzQuedr1ScMocH+ew8l233xTi+LP92gjEiviJDxselpkzgU01MUM0t6BPpfP8yMO958LDEJVg==",
+      "version": "3.0.5",
+      "resolved": "https://registry.npmjs.org/@nomicfoundation/hardhat-zod-utils/-/hardhat-zod-utils-3.0.5.tgz",
+      "integrity": "sha512-A1G9Jcizf/vYcGMtqkf+st94zBPTDB+bXXlojOMu77gmBZYbywY0k7hdRM2B4uJY+8nM0oe0sNVGVkARITXdcw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@nomicfoundation/hardhat-errors": "^3.0.0",
-        "@nomicfoundation/hardhat-utils": "^3.0.2"
+        "@nomicfoundation/hardhat-errors": "^3.0.13",
+        "@nomicfoundation/hardhat-utils": "^4.1.2"
       },
       "peerDependencies": {
         "zod": "^3.23.8"
@@ -2422,6 +2572,24 @@
         "@ethersproject/keccak256": "^5.6.1",
         "@ethersproject/logger": "^5.6.0",
         "@ethersproject/rlp": "^5.6.1"
+      }
+    },
+    "node_modules/@nomicfoundation/ignition-core/node_modules/@nomicfoundation/hardhat-utils": {
+      "version": "3.0.6",
+      "resolved": "https://registry.npmjs.org/@nomicfoundation/hardhat-utils/-/hardhat-utils-3.0.6.tgz",
+      "integrity": "sha512-AD/LPNdjXNFRrZcaAAewgJpdnHpPppZxo5p+x6wGMm5Hz4B3+oLf/LUzVn8qb4DDy9RE2c24l2F8vmL/w6ZuXg==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "@streamparser/json-node": "^0.0.22",
+        "debug": "^4.3.2",
+        "env-paths": "^2.2.0",
+        "ethereum-cryptography": "^2.2.1",
+        "fast-equals": "^5.4.0",
+        "json-stream-stringify": "^3.1.6",
+        "rfdc": "^1.3.1",
+        "undici": "^6.16.1"
       }
     },
     "node_modules/@nomicfoundation/ignition-ui": {
@@ -2787,6 +2955,15 @@
       "dev": true,
       "license": "MIT",
       "peer": true
+    },
+    "node_modules/@uniswap/v3-core": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/@uniswap/v3-core/-/v3-core-1.0.1.tgz",
+      "integrity": "sha512-7pVk4hEm00j9tc71Y9+ssYpO6ytkeI0y7WE9P6UcmNzhxPePwyAxImuhVsTqWK9YFvzgtvzJHi64pBl4jUzKMQ==",
+      "license": "BUSL-1.1",
+      "engines": {
+        "node": ">=10"
+      }
     },
     "node_modules/@yarnpkg/lockfile": {
       "version": "1.1.0",
@@ -3808,9 +3985,9 @@
       "license": "MIT"
     },
     "node_modules/fast-equals": {
-      "version": "5.2.2",
-      "resolved": "https://registry.npmjs.org/fast-equals/-/fast-equals-5.2.2.tgz",
-      "integrity": "sha512-V7/RktU11J3I36Nwq2JnZEM7tNm17eBJz+u25qdxBZeCKiX6BkVSZQjwWIr+IobgnZy+ag73tTZgZi7tr0LrBw==",
+      "version": "5.4.0",
+      "resolved": "https://registry.npmjs.org/fast-equals/-/fast-equals-5.4.0.tgz",
+      "integrity": "sha512-jt2DW/aNFNwke7AUd+Z+e6pz39KO5rzdbbFCg2sGafS4mk13MI7Z8O5z9cADNn5lhGODIgLwug6TZO2ctf7kcw==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -4135,22 +4312,21 @@
       "license": "ISC"
     },
     "node_modules/hardhat": {
-      "version": "3.0.13",
-      "resolved": "https://registry.npmjs.org/hardhat/-/hardhat-3.0.13.tgz",
-      "integrity": "sha512-7s0SmvibrFW40xA5RAi3DFDq3EciD7GC2AKmrIO4Ug0OaBTGSHSy0VXzxVJ0qwbZzJiE7Yz7PmPVJu3SvdBOcA==",
+      "version": "3.9.1",
+      "resolved": "https://registry.npmjs.org/hardhat/-/hardhat-3.9.1.tgz",
+      "integrity": "sha512-yg+0oH5tWqdsxITh6fAJjAWOSHOkC2VPlsJDJwoifs2QS1t7kyRciMy5O2F846qzH+4iqRn1rbv/5voykX3RSQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@nomicfoundation/edr": "0.12.0-next.14",
-        "@nomicfoundation/hardhat-errors": "^3.0.3",
-        "@nomicfoundation/hardhat-utils": "^3.0.5",
-        "@nomicfoundation/hardhat-zod-utils": "^3.0.1",
+        "@nomicfoundation/edr": "0.12.1",
+        "@nomicfoundation/hardhat-errors": "^3.0.16",
+        "@nomicfoundation/hardhat-utils": "^4.1.4",
+        "@nomicfoundation/hardhat-vendored": "^3.0.4",
+        "@nomicfoundation/hardhat-zod-utils": "^3.0.5",
         "@nomicfoundation/solidity-analyzer": "^0.1.1",
         "@sentry/core": "^9.4.0",
         "adm-zip": "^0.4.16",
-        "chalk": "^5.3.0",
         "chokidar": "^4.0.3",
-        "debug": "^4.3.2",
         "enquirer": "^2.3.0",
         "ethereum-cryptography": "^2.2.1",
         "micro-eth-signer": "^0.14.0",
@@ -4163,19 +4339,6 @@
       },
       "bin": {
         "hardhat": "dist/src/cli.js"
-      }
-    },
-    "node_modules/hardhat/node_modules/chalk": {
-      "version": "5.6.2",
-      "resolved": "https://registry.npmjs.org/chalk/-/chalk-5.6.2.tgz",
-      "integrity": "sha512-7NzBL0rN6fMUW+f7A6Io4h40qQlG+xGmtMxfbnH/K7TAtt8JQWVQK+6g0UXKMeVJoyV5EkkNsErQ8pVD3bLHbA==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": "^12.17.0 || ^14.13 || >=16.0.0"
-      },
-      "funding": {
-        "url": "https://github.com/chalk/chalk?sponsor=1"
       }
     },
     "node_modules/has-flag": {
@@ -5615,9 +5778,9 @@
       "peer": true
     },
     "node_modules/semver": {
-      "version": "7.7.2",
-      "resolved": "https://registry.npmjs.org/semver/-/semver-7.7.2.tgz",
-      "integrity": "sha512-RF0Fw+rO5AMf9MAyaRXI4AV0Ulj5lMHqVxxdSgiVbixSCXoEmmX/jk0CuJw4+3SqroYO9VoUh+HcuJivvtJemA==",
+      "version": "7.8.5",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.8.5.tgz",
+      "integrity": "sha512-Y7/KDsb8LjooZpwaqGyulO6DQlksgCncchHGk+sZIY4SBvUocMBEFH5Ur1fI4dV+Jvl0w6cjvucaIi40puRioA==",
       "license": "ISC",
       "bin": {
         "semver": "bin/semver.js"
@@ -6470,9 +6633,9 @@
       "license": "ISC"
     },
     "node_modules/ws": {
-      "version": "8.18.3",
-      "resolved": "https://registry.npmjs.org/ws/-/ws-8.18.3.tgz",
-      "integrity": "sha512-PEIGCY5tSlUt50cqyMXfCzX+oOPqN0vuGqWzbcJ2xvnkzkq46oOpz7dQaTDBdfICb4N14+GARUDw2XV2N4tvzg==",
+      "version": "8.21.0",
+      "resolved": "https://registry.npmjs.org/ws/-/ws-8.21.0.tgz",
+      "integrity": "sha512-Vsp28b7DRcimFQvrqu2Wek3z1iYxDCWqHYB8Qsnk/S4RfaCQzPGPyBNuVjJV3cd6UiKtUtp6sNM77gWvzcCH+g==",
       "dev": true,
       "license": "MIT",
       "engines": {

--- a/package.json
+++ b/package.json
@@ -25,6 +25,7 @@
     "@chainlink/contracts": "^1.5.0",
     "@chainlink/contracts-ccip": "^1.6.3",
     "@openzeppelin/contracts": "^5.4.0",
+    "@uniswap/v3-core": "^1.0.1",
     "ethers": "^6.15.0"
   }
 }

--- a/test/Routing.ts
+++ b/test/Routing.ts
@@ -587,6 +587,37 @@ describe("Routing on forked Mainnet", () => {
     );
   });
 
+  it("Incorrect path should throw", async function () {
+    let ethers = connection.ethers;
+    const base = await zchf.getAddress();
+    const weth = await WETH9.getAddress();
+    const validPath = ethers.solidityPacked(["address", "uint24", "address"], [base, 3000, weth]);
+
+    const badPaths = {
+      "too short": ethers.solidityPacked(["address"], [base]),
+      "bad length modulo": validPath + "00",
+      "wrong base": ethers.solidityPacked(
+        ["address", "uint24", "address"],
+        [weth, 3000, weth]),
+      "wrong payment currency": ethers.solidityPacked(
+        ["address", "uint24", "address", "uint24", "address"],
+        [base, 3000, base, 100, base]
+      ),
+    };
+
+    for (const [reason, path] of Object.entries(badPaths)) {
+      await expect(
+        aktSuite.paymentHub.getPriceInPaymentCurrency.staticCall(
+          await aktSuite.directInvestment.getAddress(),
+          1,
+          weth,
+          path
+        ),
+        reason
+      ).to.be.revertedWithCustomError(aktSuite.paymentHub, "PaymentHub_InvalidPath");
+    }
+  });
+
   it("should be able to pay with native ETH", async function () {
     let ethers = connection.ethers;
 
@@ -613,12 +644,6 @@ describe("Routing on forked Mainnet", () => {
     const USDT_ZCHF_V3POOL_ADDRESS =
       "0x8E4318E2cb1ae291254B187001a59a1f8ac78cEF";
 
-    const pools: Address[] = [
-      "0x8E4318E2cb1ae291254B187001a59a1f8ac78cEF",
-      "0x4e68Ccd3E89f51C3074ca5072bbAC773960dFa36",
-    ];
-    // true: direction is correct, else price has to be inverted
-    // const pools_direction = [true, false]
     const path: V3Path[] = [
       ZCHF_ADDRESS,
       "100",
@@ -863,8 +888,6 @@ describe("Routing on forked Mainnet", () => {
       } else {
         await aktSuite.paymentHub.approveERC20(externalToken_ADDRESS);
       }
-      // await aktSuite.paymentHub
-      //   .approveERC20(externalToken_ADDRESS);
 
       // we swap external token for shares
       const ref = ethers.hexlify(ethers.toUtf8Bytes("my-ref"));

--- a/test/Routing.ts
+++ b/test/Routing.ts
@@ -1,0 +1,923 @@
+/**
+ * Tests are dedicateed to routing function through uniswap V3.
+ * Function of interest are:
+ *
+ * - payFromOtherCurrencyAndNotify
+ * 		Pays shares with any ERC20 token that can be routed through uniswap to the base token of DirectInvestment.
+ *
+ * - payFromEtherAndNotify
+ * 		Pays shares with gas ETH if it can be routed through uniswap to the base token of DirectInvestment.
+ *
+ * From PaymentHub contract.
+ */
+import { network } from "hardhat";
+import type { NetworkConnection } from "hardhat/types/network";
+
+import { Contract } from "ethers";
+import type { BigNumberish, Signer } from "ethers";
+
+import { expect } from "chai";
+
+// Abis, Interfaces
+// legacy quoter and router as sol implements those
+import V3PoolJson from "@uniswap/v3-core/artifacts/contracts/UniswapV3Pool.sol/UniswapV3Pool.json" with { type: 'json' };
+import WETHJson from "../artifacts/contracts/investment/IUniswapV3.sol/IWETH9.json" with { type: 'json' };
+const PATH_IERC20 = "contracts/ERC20/IERC20.sol:IERC20";
+
+// Addresses
+import { ZCHF_ADDRESS } from "./Fixtures.ts";
+const WBTC_ADDRESS = "0x2260FAC5E5542a773Aa44fBCfeDf7C193bc2C599";
+
+/**
+ * List of all possible external tokens to be used within routing to buy shares.
+ * The list is as follows:
+ *
+ * imperFunder_ADDRESS: "0x...",
+ *    the address we can impersonificate to fund the investor address with the external token.
+ *
+ * imperFunder_AMOUNT: number,
+ *    the amount of token to be sent to the investor from the impersonificated address. Note that
+ *    as shares increase in price as the investor buys them you need to account for such increase,
+ *    we recommend to fund with an amount of 1000.- with an increase of 200.- for each new token,
+ *    increase is cumulative by order of keys definition. Consider it with no decimals, the decimal
+ *    normalization is taken care of.
+ *
+ * It is important to note that for imperFunder_ADDRESS and imperFunder_AMOUNT you need to consider
+ * quantities and prices of block 25464800.
+ *
+ * address: "0x.."
+ *    the address of the external token.
+ *
+ * path: ["address", "uint24", "address", "uint24", "address", ...],
+ *    where the first address is the output token, the last address the input token
+ *    and the "unit24" is the fee of the pool between the two adjacent token addresses.
+ *    Note: you need to follow exactOutput format, so from the out token to the input token.
+ *
+ * pools: ["0x...", "0x..."],
+ *    the address of pools that are used within the path, following also the same order.
+ */
+type ExternalTokenName = "WETH" | "WBTC" | "USDC" | "USDT" | "DAI";
+
+type Address = `0x${string}`;
+type V3Path = `0x${string}` | `${number}`;
+
+type ExternalToken = {
+  imperFunder_ADDRESS: Address;
+  imperFunder_AMOUNT: number;
+  address: Address;
+  path: V3Path[];
+  pools: Address[];
+};
+
+type ExternalTokens<T extends string> = {
+  [K in T]: ExternalToken;
+};
+
+// Recurrent elements within external tokens paths
+const PATH_FROM_USDT_TO_ZCHF_UNIV3: V3Path[] = [
+  "0xB58E61C3098d85632Df34EecfB899A1Ed80921cB",
+  "100", // https://app.uniswap.org/explore/pools/ethereum/0x8E4318E2cb1ae291254B187001a59a1f8ac78cEF
+  "0xdAC17F958D2ee523a2206206994597C13D831ec7",
+];
+const POOL_USDT_ZCHF_UNIV3: Address =
+  "0x8E4318E2cb1ae291254B187001a59a1f8ac78cEF";
+
+const EXTERNAL_TOKENS: ExternalTokens<ExternalTokenName> = {
+  // WETH: works only for direct payment with gas ether
+  WETH: {
+    imperFunder_ADDRESS: "0x4b7fEcEffE3b14fFD522e72b711B087f08BD98Ab",
+    imperFunder_AMOUNT: 10,
+
+    address: "0xC02aaA39b223FE8D0A0e5C4F27eAD9083C756Cc2",
+
+    path: [
+      ...PATH_FROM_USDT_TO_ZCHF_UNIV3,
+      "500", // https://app.uniswap.org/explore/pools/ethereum/0x11b815efB8f581194ae79006d24E0d814B7697F6
+      // "3000", // https://app.uniswap.org/explore/pools/ethereum/0x4e68Ccd3E89f51C3074ca5072bbAC773960dFa36   If price impact drawback exceedes swapped fees, this could be better
+      "0xC02aaA39b223FE8D0A0e5C4F27eAD9083C756Cc2",
+    ],
+    pools: [POOL_USDT_ZCHF_UNIV3, "0x11b815efB8f581194ae79006d24E0d814B7697F6"],
+  },
+
+  // BTC
+  WBTC: {
+    imperFunder_ADDRESS: "0x652356478073bA1D38b310850446d0A4C3Cad4BD",
+    imperFunder_AMOUNT: 10,
+
+    address: WBTC_ADDRESS,
+
+    path: [
+      ...PATH_FROM_USDT_TO_ZCHF_UNIV3,
+      "500", // https://app.uniswap.org/explore/pools/ethereum/0x56534741CD8B152df6d48AdF7ac51f75169A83b2?chart=liquidity
+      // "3000", // http://app.uniswap.org/explore/pools/ethereum/0x9Db9e0e53058C89e5B94e29621a205198648425B
+      WBTC_ADDRESS,
+    ],
+    pools: [POOL_USDT_ZCHF_UNIV3, "0x56534741CD8B152df6d48AdF7ac51f75169A83b2"],
+  },
+
+  // Stablecoins
+  USDC: {
+    imperFunder_ADDRESS: "0x01b8697695EAb322A339c4bf75740Db75dc9375E",
+    imperFunder_AMOUNT: 10_000,
+
+    address: "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48",
+
+    path: [
+      ...PATH_FROM_USDT_TO_ZCHF_UNIV3,
+      "100", // https://app.uniswap.org/explore/pools/ethereum/0x3416cF6C708Da44DB2624D63ea0AAef7113527C6
+      "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48",
+    ],
+    pools: [POOL_USDT_ZCHF_UNIV3, "0x3416cF6C708Da44DB2624D63ea0AAef7113527C6"],
+  },
+  USDT: {
+    imperFunder_ADDRESS: "0x3fe705e2FFcaEe8d7287de047DeF35Db3e794C76",
+    imperFunder_AMOUNT: 10_000,
+
+    address: "0xdac17f958d2ee523a2206206994597c13d831ec7",
+
+    path: PATH_FROM_USDT_TO_ZCHF_UNIV3,
+    pools: [POOL_USDT_ZCHF_UNIV3],
+  },
+  DAI: {
+    imperFunder_ADDRESS: "0x415D8D075CAcB5A61Ae854A8e5ea53DF3A76F688",
+    imperFunder_AMOUNT: 10_000,
+
+    address: "0x6b175474e89094c44da98b954eedeac495271d0f",
+
+    path: [
+      ...PATH_FROM_USDT_TO_ZCHF_UNIV3,
+      "100", // https://app.uniswap.org/explore/pools/ethereum/0x48DA0965ab2d2cbf1C17C09cFB5Cbe67Ad5B1406
+      "0x6b175474e89094c44da98b954eedeac495271d0f",
+    ],
+    pools: [POOL_USDT_ZCHF_UNIV3, "0x48DA0965ab2d2cbf1C17C09cFB5Cbe67Ad5B1406"],
+  },
+};
+
+interface InvestmentAktionariatContracts {
+  directInvestment: Contract;
+  paymentHub: Contract;
+}
+
+/**
+ * Impersonificate adress from on the network to transfer quantity of tokenToTransfer to address to
+ *
+ * @param connection hardhat connection
+ * @param from the address to transfer from
+ * @param to the address to transfer to
+ * @param tokenToTransfer the token to transfer
+ * @param quantity the quantity to transfer
+ */
+async function impersonificateAndTransferToken(
+  connection: NetworkConnection,
+  from: string,
+  to: string,
+  tokenToTransfer: string,
+  quantity: BigNumberish
+) {
+  // we impersonate an address to fund owned addresses with tokenToTransfer
+  await connection.provider.request({
+    method: "hardhat_impersonateAccount",
+    params: [from],
+  });
+  const imperFunder = await connection.ethers.getSigner(from);
+
+  const token = await connection.ethers.getContractAt(
+    PATH_IERC20,
+    tokenToTransfer
+  );
+
+  // transfter token to "to"
+  // @ts-expect-error
+  await token.connect(imperFunder).transfer(to, quantity);
+
+  // stop impersonating
+  await connection.provider.request({
+    method: "hardhat_stopImpersonatingAccount",
+    params: [from],
+  });
+}
+
+/**
+ * Deploys th Aktionariat direct investment suite: DirectInvestment and PaymentHub contracts
+ *
+ * @param connection hardhat connection
+ * @param deployer the deployer address
+ * @param shareToken the share token of DirectInvestment
+ * @param price the price of shares
+ * @param increment the increment of shares price
+ * @param base the base token used to buy shares
+ * @param quoter the Uniswap V3 quoter address
+ * @param swapRouter the Uniswap V3 router address
+ * @returns
+ */
+async function deployInvestmentAktionariatSuide(
+  connection: NetworkConnection,
+  deployer: Signer,
+
+  shareToken: string,
+  price: BigNumberish,
+  increment: BigNumberish,
+  base: string,
+
+  quoter: string,
+  swapRouter: string
+): Promise<InvestmentAktionariatContracts> {
+  let ethers = connection.ethers;
+  // shares token
+  // either we deploy mock erc20, but we need to make a pool on uni: we can also use Shares
+  //        we impersonificate a whale with a token and zchf and transfer funds: we can fix tests by choosing block
+  // we choose latter and pass them as arguments
+
+  const PaymentHub = await ethers.getContractFactory("PaymentHub");
+  // address _owner,
+  // IQuoter _uniswapV3Quoter,
+  // ISwapRouter _uniswapV3SwapRouter
+  const paymentHub = await PaymentHub.connect(deployer).deploy(
+    deployer,
+    quoter,
+    swapRouter
+  );
+  await paymentHub.waitForDeployment();
+
+  const DirectInvestment = await ethers.getContractFactory("DirectInvestment");
+  // IERC20 _token,
+  // uint256 _price,
+  // uint256 _increment,
+  // IERC20 _base,
+  // address _owner,
+  // address _paymentHub
+  const directInvestment = await DirectInvestment.connect(deployer).deploy(
+    shareToken,
+    price,
+    increment,
+    base,
+    deployer,
+    paymentHub
+  );
+  await directInvestment.waitForDeployment();
+
+  return {
+    directInvestment: directInvestment as unknown as Contract,
+    paymentHub: paymentHub as unknown as Contract,
+  };
+}
+
+/**
+ * Computes from the stored Uniswap sqrtPriceX96 the price in unit256 (bigint) normalized by decimal
+ * To maintain precision we scale division by 18 decimals, so you get `price * 10n ** 18n`
+ *
+ * @param slot0 Uniswap Pool response from slot0() view function
+ * @param decimals0 decimals of the over token
+ * @param decimals1 decimals of the under token
+ * @returns price in unit256 (bigint) normalized by decimal
+ */
+function getPriceFromPool(
+  slot0: { sqrtPriceX96: bigint },
+  decimals0: bigint,
+  decimals1: bigint
+): bigint {
+  const Q192 = 2n ** 192n;
+
+  const numerator = slot0.sqrtPriceX96 * slot0.sqrtPriceX96 * 10n ** decimals0;
+
+  const denominator = Q192 * 10n ** decimals1;
+
+  return (numerator * 10n ** 18n) / denominator;
+}
+
+/**
+ * Queries each pool token for decimal and returns it
+ *
+ * @param POOL the uniswap V3 AMM Contract of the pool
+ * @returns both tokens decimal
+ */
+async function getDecimalsPool(
+  POOL: Contract,
+  ethers: any
+): Promise<{ decimal0: bigint; decimal1: bigint }> {
+  const TOKEN0_ADDRESS = await POOL.token0();
+  const TOKEN1_ADDRESS = await POOL.token1();
+  return {
+    decimal0: await (
+      await ethers.getContractAt(PATH_IERC20, TOKEN0_ADDRESS)
+    ).decimals(),
+    decimal1: await (
+      await ethers.getContractAt(PATH_IERC20, TOKEN1_ADDRESS)
+    ).decimals(),
+  };
+}
+
+/**
+ * Computes whether the swap needs to be reverted or not from addresses
+ *
+ * @param tokenIn address of token to be swapped
+ * @param tokenOut address of token to return after swap
+ * @param token0 address of token0
+ * @param token1 address of token1
+ * @returns whether the swap needs to be reverted or not
+ */
+function getPoolDirection(
+  tokenIn: string,
+  tokenOut: string,
+  token0: string,
+  token1: string
+) {
+  if (
+    tokenIn.toLowerCase() === token0.toLowerCase() &&
+    tokenOut.toLowerCase() === token1.toLowerCase()
+  ) {
+    return false;
+  }
+
+  if (
+    tokenIn.toLowerCase() === token1.toLowerCase() &&
+    tokenOut.toLowerCase() === token0.toLowerCase()
+  ) {
+    return true;
+  }
+
+  throw new Error("Pool does not contain requested pair");
+}
+
+/**
+ * From a list of UniswapV3 pools, and expected output quantity it computes the expected amount in.
+ * It expects the path to be in the EACT_OUTPUT format.
+ * It expects pools to be correctly chained
+ *
+ * @param path the UniswapV3 pools path
+ * @param amountOut the expected amount out
+ * @return returns the expected amount in
+ */
+async function getExpectedAmountIn(
+  ethers: any,
+  path: V3Path[],
+  pools: Address[],
+  amountOut: bigint
+): Promise<bigint> {
+  // path holds the same as pools but token and fees wise
+  const no_fees_path = path.filter((v) => v.startsWith("0x"));
+
+  let amountIn = 0n;
+  for (let i = 0; i < pools.length; i++) {
+    const pool = pools[i];
+    const V3Pool = new ethers.Contract(pool, V3PoolJson.abi, ethers.provider);
+
+    const slot0 = await V3Pool.slot0();
+    const decimalsPool = await getDecimalsPool(V3Pool, ethers);
+
+    // extract price in bigint WETH/USDC
+    let real_price = getPriceFromPool(
+      slot0,
+      decimalsPool.decimal0,
+      decimalsPool.decimal1
+    );
+
+    // to make it decimal aware here requires more then needed
+    const PRICE_SCALE = 10n ** 18n;
+    let price = real_price;
+
+    if (
+      !getPoolDirection(
+        no_fees_path[i + 1],
+        no_fees_path[i],
+        await V3Pool.token0(),
+        await V3Pool.token1()
+      )
+    ) {
+      price = (PRICE_SCALE * PRICE_SCALE) / price;
+    }
+
+    // recursively compute cost
+    amountIn = ((amountIn == 0n ? amountOut : amountIn) * price) / PRICE_SCALE;
+  }
+
+  return amountIn;
+}
+
+describe("Routing on forked Mainnet", () => {
+  let connection: NetworkConnection;
+
+  const USDT_ADDRESS = "0xdAC17F958D2ee523a2206206994597C13D831ec7";
+
+  const Quoter_ADDRESS = "0xb27308f9F90D607463bb33eA1BeBb41C27CE5AB6";
+  const SwapRouter_ADDRESS = "0xE592427A0AEce92De3Edee1F18E0157C05861564";
+
+  const WETH9_ADDRESS = "0xC02aaA39b223FE8D0A0e5C4F27eAD9083C756Cc2";
+  let WETH9: Contract;
+
+  let zchf: Contract;
+
+  const shareToken_ADDRESS = "0xae78736Cd615f374D3085123A210448E74Fc6393";
+  let shareToken: Contract;
+  const SHARES_TO_BUY = 5;
+  const SHARE_COST = 10;
+  const SHARE_INCREASE = 5;
+
+  const imperFunder_ADDRESS = "0xC249626c215d1788942240bba86FcC95FD138a30";
+
+  let akt_deployer: Signer;
+  let aktSuite: InvestmentAktionariatContracts;
+
+  let uni_deployer: Signer;
+
+  let investor: Signer;
+  let investor2: Signer;
+
+  before(async () => {
+    // This test uses the forked Mainnet network (ETH mainnet)
+    connection = await network.create("mainnetForkAtBlock25464800");
+    let ethers = connection.ethers;
+
+    [akt_deployer, uni_deployer, investor, investor2] =
+      await ethers.getSigners();
+
+    // read zchf: base token
+    zchf = await ethers.getContractAt(PATH_IERC20, ZCHF_ADDRESS);
+
+    // read rETH: share token
+    shareToken = await ethers.getContractAt(PATH_IERC20, shareToken_ADDRESS);
+
+    // we impersonate an address to fund owned addresses with zchf and share token
+    // zchf has decimal of 18
+    impersonificateAndTransferToken(
+      connection,
+      imperFunder_ADDRESS,
+      await akt_deployer.getAddress(),
+      await zchf.getAddress(),
+      ethers.parseUnits("1000", 18)
+    );
+    // shares have decimal of 0
+    impersonificateAndTransferToken(
+      connection,
+      imperFunder_ADDRESS,
+      await akt_deployer.getAddress(),
+      await shareToken.getAddress(),
+      1000n
+    );
+
+    WETH9 = new ethers.Contract(WETH9_ADDRESS, WETHJson.abi, uni_deployer);
+
+    aktSuite = await deployInvestmentAktionariatSuide(
+      connection,
+      akt_deployer,
+      await shareToken.getAddress(),
+      ethers.parseUnits(SHARE_COST.toString(), 18),
+      ethers.parseUnits(SHARE_INCREASE.toString(), 18),
+      await zchf.getAddress(),
+      Quoter_ADDRESS,
+      SwapRouter_ADDRESS
+    );
+  });
+
+  it("should fund DirectInvestment, see price for shares and notify transfer", async function () {
+    let ethers = connection.ethers;
+
+    // // funding direct investment
+    // 500 rETH shares at 0 decimal
+    await expect(
+      shareToken
+        .connect(akt_deployer)
+        // @ts-expect-error
+        .transfer(await aktSuite.directInvestment.getAddress(), 500n)
+    ).to.changeTokenBalance(
+      ethers,
+      shareToken,
+      await aktSuite.directInvestment.getAddress(),
+      500n
+    );
+
+    // // price check
+    // compute price naively
+    let price = 0;
+    let priceAfter = SHARE_COST + SHARES_TO_BUY * SHARE_INCREASE;
+    for (let i = 0; i < SHARES_TO_BUY; i++) {
+      price = price + SHARE_COST + i * SHARE_INCREASE;
+    }
+
+    let normPrice = ethers.parseUnits(price.toString(), 18);
+    expect(
+      await aktSuite.directInvestment.getBuyPrice(SHARES_TO_BUY)
+    ).to.be.equal(normPrice, `Price does not equal ${normPrice}`);
+
+    // // notify check
+    // address buyer,
+    // uint256 amountShares,
+    // uint256 amountBaseCurrency,
+    // bytes calldata ref
+    const ref = ethers.hexlify(ethers.toUtf8Bytes("my-ref"));
+
+    const transfer_tx = aktSuite.directInvestment.notifyTradeAndTransfer(
+      investor,
+      ethers.parseUnits(SHARES_TO_BUY.toString(), 0),
+      ethers.parseUnits("10", 18), // arbitrary
+      ref
+    );
+
+    await expect(transfer_tx)
+      .to.emit(aktSuite.directInvestment, "Trade")
+      .withArgs(
+        await shareToken.getAddress(),
+        await investor.getAddress(),
+        ref,
+        ethers.parseUnits(SHARES_TO_BUY.toString(), 0),
+        await zchf.getAddress(),
+        ethers.parseUnits("10", 18),
+        0,
+        ethers.parseUnits(priceAfter.toString(), 18)
+      );
+
+    await expect(transfer_tx).to.changeTokenBalances(
+      ethers,
+      shareToken,
+      [
+        await investor.getAddress(),
+        await aktSuite.directInvestment.getAddress(),
+      ],
+      [
+        ethers.parseUnits(SHARES_TO_BUY.toString(), 0),
+        -ethers.parseUnits(SHARES_TO_BUY.toString(), 0),
+      ]
+    );
+
+    // notify all check
+    const batch_transfer_tx = aktSuite.directInvestment.notifyTradesAndTransfer(
+      [investor, investor2],
+      [
+        ethers.parseUnits(SHARES_TO_BUY.toString(), 0),
+        ethers.parseUnits(SHARES_TO_BUY.toString(), 0),
+      ],
+      [ethers.parseUnits("10", 18), ethers.parseUnits("10", 18)], // arbitrary
+      [ref, ref]
+    );
+
+    let priceAfterFirstBatchTransfer =
+      priceAfter + SHARES_TO_BUY * SHARE_INCREASE;
+    let priceAfterSecondBatchTransfer =
+      priceAfterFirstBatchTransfer + SHARES_TO_BUY * SHARE_INCREASE;
+    await expect(batch_transfer_tx)
+      .to.emit(aktSuite.directInvestment, "Trade")
+      .withArgs(
+        await shareToken.getAddress(),
+        await investor.getAddress(),
+        ref,
+        ethers.parseUnits(SHARES_TO_BUY.toString(), 0),
+        await zchf.getAddress(),
+        ethers.parseUnits("10", 18),
+        0,
+        ethers.parseUnits(priceAfterFirstBatchTransfer.toString(), 18)
+      )
+      .to.emit(aktSuite.directInvestment, "Trade")
+      .withArgs(
+        await shareToken.getAddress(),
+        await investor2.getAddress(),
+        ref,
+        ethers.parseUnits(SHARES_TO_BUY.toString(), 0),
+        await zchf.getAddress(),
+        ethers.parseUnits("10", 18),
+        0,
+        ethers.parseUnits(priceAfterSecondBatchTransfer.toString(), 18)
+      );
+
+    // Final check of shares balance on contract
+    expect(
+      await shareToken.balanceOf(await aktSuite.directInvestment.getAddress())
+    ).to.be.equal(
+      ethers.parseUnits((500 - SHARES_TO_BUY * 3).toString(), 0),
+      `Balance of direct investment is incorrect`
+    );
+  });
+
+  it("should be able to pay with native ETH", async function () {
+    let ethers = connection.ethers;
+
+    // direct investment is funded
+
+    // we build the path manually from WETH to ZCHF
+    const ref = ethers.hexlify(ethers.toUtf8Bytes("my-ref"));
+
+    // https://developers.uniswap.org/docs/protocols/v3/guides/swapping/multi-hop-swapping#exact-output-multihop-swap
+    // Path is in reverse order as router computes starting from desired amount in output to get how much input is needed
+    // For route:     TokenA -> TokenB -> TokenC
+    // Encoding is:   TokenC | feeBC | TokenB | feeAB | TokenA, where TokenX is Address of 20 bytes and feeAB fees in bps as unit24 (3 bytes)
+    // in solidty abi.encodepacked
+    // in ethers ethers.solidityPacked(["address", "uint24", "address"], [tokenOut, 3000, tokenIn])
+    //
+    // price is encoded token1 / token0
+
+    // From WETH to USDT (V3) 0.3%
+    // https://app.uniswap.org/explore/pools/ethereum/0x4e68Ccd3E89f51C3074ca5072bbAC773960dFa36
+    const WETH_USDT_V3POOL_ADDRESS =
+      "0x4e68Ccd3E89f51C3074ca5072bbAC773960dFa36";
+    // From USDT to ZCHF (V3) 0.01%
+    // https://app.uniswap.org/explore/pools/ethereum/0x8E4318E2cb1ae291254B187001a59a1f8ac78cEF
+    const USDT_ZCHF_V3POOL_ADDRESS =
+      "0x8E4318E2cb1ae291254B187001a59a1f8ac78cEF";
+
+    const pools: Address[] = [
+      "0x8E4318E2cb1ae291254B187001a59a1f8ac78cEF",
+      "0x4e68Ccd3E89f51C3074ca5072bbAC773960dFa36",
+    ];
+    // true: direction is correct, else price has to be inverted
+    // const pools_direction = [true, false]
+    const path: V3Path[] = [
+      ZCHF_ADDRESS,
+      "100",
+      USDT_ADDRESS,
+      "3000",
+      (await WETH9.getAddress()) as Address,
+    ];
+
+    const packedPath = ethers.solidityPacked(
+      path.map((v) => (v.startsWith("0x") ? "address" : "uint24")),
+      path
+    );
+
+    // we naively compute amount needed
+    let WETH_USDT_V3Pool = new ethers.Contract(
+      WETH_USDT_V3POOL_ADDRESS,
+      V3PoolJson.abi,
+      ethers.provider
+    );
+    let USDT_ZCHF_V3Pool = new ethers.Contract(
+      USDT_ZCHF_V3POOL_ADDRESS,
+      V3PoolJson.abi,
+      ethers.provider
+    );
+
+    // https://github.com/Uniswap/v3-core/blob/d0831dc6b8a318df3872b6d68f6de135c9f3ec29/contracts/interfaces/pool/IUniswapV3PoolState.sol#L21
+    const resWethUsdtSlot0 = await WETH_USDT_V3Pool.slot0();
+    const decimalsWethUsdt = await getDecimalsPool(WETH_USDT_V3Pool, ethers);
+
+    // extract price in bigint WETH/USDC
+    const priceWethUsdt = getPriceFromPool(
+      resWethUsdtSlot0,
+      decimalsWethUsdt.decimal0,
+      decimalsWethUsdt.decimal1
+    );
+
+    let fpriceWethUsdt = Number(priceWethUsdt) / 1e18;
+    let fpriceUsdtWeth = 1 / fpriceWethUsdt;
+
+    let priceUsdtWeth = 10n ** 36n / priceWethUsdt;
+
+    // console.log(`1 WETH/USDT = ${fpriceWethUsdt}`)
+    // console.log(`1 USDT/WETH = ${fpriceUsdtWeth}`)
+    // console.log(`1 USDT/WETH = ${priceUsdtWeth}`)
+
+    const resUsdtZchfSlot0 = await USDT_ZCHF_V3Pool.slot0();
+    const decimalsUsdtZchf = await getDecimalsPool(USDT_ZCHF_V3Pool, ethers);
+
+    // extract price in bigint ZCHF/USDT
+    const priceZchfUsdt = getPriceFromPool(
+      resUsdtZchfSlot0,
+      decimalsUsdtZchf.decimal0,
+      decimalsUsdtZchf.decimal1
+    );
+
+    let fpriceZchfUsdt = Number(priceZchfUsdt) / 1e18;
+    let fpriceUsdtZchf = 1 / fpriceZchfUsdt;
+
+    // console.log(`1 USDT/ZCHF = ${fpriceUsdtZchf}`)
+    // console.log(`1 ZCHF/USDT = ${fpriceZchfUsdt}`)
+
+    // compute expected WETH to be spend for SHARES_TO_BUY
+    // cost is
+    const baseCost: bigint = await aktSuite.directInvestment.getBuyPrice(
+      SHARES_TO_BUY
+    );
+    // console.log(`to pay: ${baseCost} in base currency (CHF * 1e18)`)
+
+    const normalizedBaseCost =
+      Number(baseCost) / Number(10n ** decimalsUsdtZchf.decimal0);
+    // console.log(`to pay: ${normalizedBaseCost} normalized in base currency (CHF)`)
+
+    // we expect to spend normalizedBaseCost of ZCHF in WETH: normalizedBaseCost ZCHF * ZCHF/USDT * USDT/WETH = WETH
+    // big int math is as good as float
+    const expectedWethToBeSpent =
+      (((baseCost * priceZchfUsdt) / 10n ** 18n) * priceUsdtWeth) / 10n ** 18n;
+
+    // check price
+    // IDirectInvestment directInvestment,
+    // uint256 amountShares,
+    // IERC20 paymentCurrency,
+    // bytes calldata path
+    // since it is not market as view we dont send a txn but an eth_call through staticCall
+    const expectedIn =
+      await aktSuite.paymentHub.getPriceInPaymentCurrency.staticCall(
+        await aktSuite.directInvestment.getAddress(),
+        ethers.parseUnits(SHARES_TO_BUY.toString(), 0),
+        await WETH9.getAddress(),
+        packedPath
+      );
+    expect(expectedIn).to.be.approximately(
+      expectedWethToBeSpent,
+      ethers.parseUnits("0.01", 18),
+      "Expected payment in WETH differs"
+    );
+    // approximation since we do not take into account for fees and slippage of the routing in expectedWethToBeSpent
+
+    // beforehand approve WETH for spending
+    await aktSuite.paymentHub
+      .connect(investor)
+      // @ts-expect-error
+      .approveERC20(await WETH9.getAddress());
+
+    // IDirectInvestment directInvestment,
+    // uint256 amountShares,
+    // bytes calldata path,
+    // bytes calldata ref
+    const trade_tx = aktSuite.paymentHub
+      .connect(investor)
+      // @ts-expect-error
+      .payFromEtherAndNotify(
+        await aktSuite.directInvestment.getAddress(),
+        ethers.parseUnits(SHARES_TO_BUY.toString(), 0),
+        packedPath,
+        ref,
+        {
+          // then expectedIn should be used to purchase shares while the rest refunded as WETH
+          value: ethers.parseUnits("1", 18),
+        }
+      );
+
+    // change in shares token balance
+    await expect(trade_tx).to.be.changeTokenBalances(
+      ethers,
+      shareToken,
+      [
+        await investor.getAddress(),
+        await aktSuite.directInvestment.getAddress(),
+      ],
+      [
+        ethers.parseUnits(SHARES_TO_BUY.toString(), 0),
+        -ethers.parseUnits(SHARES_TO_BUY.toString(), 0),
+      ]
+    );
+
+    // expected WETH to be returned to investor
+    expect(
+      await WETH9.balanceOf(await investor.getAddress())
+    ).to.be.approximately(
+      ethers.parseUnits("1", 18) - expectedWethToBeSpent,
+      ethers.parseUnits("0.01", 18),
+      "returned WETH not correct"
+    );
+
+    // expect base token to be held by paymenthub after payment
+    expect(
+      await zchf.balanceOf(await aktSuite.directInvestment.getAddress())
+    ).to.be.equal(baseCost, "returned WETH not correct");
+  });
+
+  for (let i = 0; i < Object.keys(EXTERNAL_TOKENS).length; i++) {
+    const TOKEN_TICKER: ExternalTokenName = Object.keys(EXTERNAL_TOKENS)[
+      i
+    ] as ExternalTokenName;
+
+    it(`should be able to find route from external token ${TOKEN_TICKER} to ZCHF`, async function () {
+      // should make programmatic impersonification and external token wrapping in contract
+      // and programmatic path testign within it(...)
+      let ethers = connection.ethers;
+
+      // compute path: we decided to follow hardcoded path
+      const path = EXTERNAL_TOKENS[TOKEN_TICKER].path;
+      const packedPath = ethers.solidityPacked(
+        path.map((v) => (v.startsWith("0x") ? "address" : "uint24")),
+        path
+      );
+
+      const pools = EXTERNAL_TOKENS[TOKEN_TICKER].pools;
+      const externalToken_ADDRESS = EXTERNAL_TOKENS[TOKEN_TICKER].address;
+
+      // decimal of token
+      const decimals: bigint = await (
+        await ethers.getContractAt(PATH_IERC20, externalToken_ADDRESS)
+      ).decimals();
+
+      // read arbitrary TOKEN_TICKER external token
+      const externalToken = await ethers.getContractAt(
+        PATH_IERC20,
+        externalToken_ADDRESS
+      );
+
+      // external token transfer
+      await impersonificateAndTransferToken(
+        connection,
+        EXTERNAL_TOKENS[TOKEN_TICKER].imperFunder_ADDRESS,
+        await investor.getAddress(),
+        externalToken_ADDRESS,
+        ethers.parseUnits(
+          EXTERNAL_TOKENS[TOKEN_TICKER].imperFunder_AMOUNT.toString(),
+          decimals
+        )
+      );
+
+      const directInvestmentBaseBalance: bigint = await zchf.balanceOf(
+        await aktSuite.directInvestment.getAddress()
+      );
+      const cost: bigint = await aktSuite.directInvestment.getBuyPrice(
+        SHARES_TO_BUY
+      );
+      const balanceInvestorExternalTokens: bigint =
+        await externalToken.balanceOf(await investor.getAddress());
+
+      // either we clamp it to decimals or we compute it decimal aware
+      const expectedExternalTokenToBeSpent_e18 = await getExpectedAmountIn(
+        ethers,
+        path,
+        pools,
+        cost
+      );
+      // we clamp it to exact decimal:
+      const expectedExternalTokenToBeSpent =
+        expectedExternalTokenToBeSpent_e18 / 10n ** (18n - decimals);
+
+      // compute prevented cost
+      // returned in externalToken_ADDRESS decimals
+      const expectedIn =
+        await aktSuite.paymentHub.getPriceInPaymentCurrency.staticCall(
+          await aktSuite.directInvestment.getAddress(),
+          ethers.parseUnits(SHARES_TO_BUY.toString(), 0),
+          externalToken_ADDRESS,
+          packedPath
+        );
+      expect(expectedIn).to.be.approximately(
+        expectedExternalTokenToBeSpent,
+        // decimality approximation depends on external token decimals
+        expectedExternalTokenToBeSpent / 100n,
+        `Expected payment in ${TOKEN_TICKER} differs`
+      );
+
+      // Approve the external payment token from the investor to the PaymentHub.
+      await externalToken
+        .connect(investor)
+        //@ts-expect-error
+        .approve(
+          await aktSuite.paymentHub.getAddress(),
+          balanceInvestorExternalTokens * 10n
+        );
+
+      // Approve the router to spend the external token from PaymentHub.
+      if (TOKEN_TICKER == "USDT") {
+        await aktSuite.paymentHub.silentApproveERC20(externalToken_ADDRESS);
+      } else {
+        await aktSuite.paymentHub.approveERC20(externalToken_ADDRESS);
+      }
+      // await aktSuite.paymentHub
+      //   .approveERC20(externalToken_ADDRESS);
+
+      // we swap external token for shares
+      const ref = ethers.hexlify(ethers.toUtf8Bytes("my-ref"));
+      const trade_tx = aktSuite.paymentHub
+        .connect(investor)
+        // @ts-expect-error
+        .payFromOtherCurrencyAndNotify(
+          await aktSuite.directInvestment.getAddress(),
+          ethers.parseUnits(SHARES_TO_BUY.toString(), 0),
+          // IERC20 paymentCurrency,
+          externalToken_ADDRESS,
+          // uint256 amountInMaximum
+          // amount gets depsoited beforehand, so it should be greater than expected payment but less than or equal to
+          // capacity to be spent
+          balanceInvestorExternalTokens,
+          packedPath,
+          ref
+        );
+
+      // After transfer balances
+
+      // change in shares token balance
+      await expect(trade_tx).to.be.changeTokenBalances(
+        ethers,
+        shareToken,
+        [
+          await investor.getAddress(),
+          await aktSuite.directInvestment.getAddress(),
+        ],
+        [
+          ethers.parseUnits(SHARES_TO_BUY.toString(), 0),
+          -ethers.parseUnits(SHARES_TO_BUY.toString(), 0),
+        ]
+      );
+
+      // expected external token to be returned to inverstor
+      const approximatedDeltaExternalTokenBalance =
+        balanceInvestorExternalTokens - expectedExternalTokenToBeSpent;
+      expect(
+        await externalToken.balanceOf(await investor.getAddress())
+      ).to.be.approximately(
+        approximatedDeltaExternalTokenBalance,
+        approximatedDeltaExternalTokenBalance / 100n,
+        `returned ${TOKEN_TICKER} not correct`
+      );
+
+      // expect base token to be held by paymenthub after payment
+      expect(
+        await zchf.balanceOf(await aktSuite.directInvestment.getAddress())
+      ).to.be.equal(
+        directInvestmentBaseBalance + cost,
+        "ZCHF balance of direct investment is not correct"
+      );
+    });
+  }
+});


### PR DESCRIPTION
### Route Testing

The objective was to test and implement different routing paths from external tokens and native ETH to be exchanged by the Uniswap V3 router to ZCHF.

Testing is separated into, basic functionality testing of `DirectInvestment.sol`, native ETH payment and programmatic testing of external currencies defined within `EXTERNAL_TOKENS` in `test/Routing.ts`.

### Routes

Routes are defined within `EXTERNAL_TOKENS` and with the interface:

```ts
type ExternalTokenName = "WETH" | "WBTC" | "USDC" | "USDT" | "DAI";

type Address = `0x${string}`;
type V3Path = `0x${string}` | `${number}`;

type ExternalToken = {
  imperFunder_ADDRESS: Address;
  imperFunder_AMOUNT: number;
  address: Address;
  path: V3Path[];
  pools: Address[];
};

type ExternalTokens<T extends string> = {
  [K in T]: ExternalToken;
};

const EXTERNAL_TOKENS: ExternalTokens<ExternalTokenName> = //...
```

I spend some words about it because a new entry will generate a new test case.

- `imperFunder_ADDRESS: "0x..."`, is the address we can impersonificate to fund the investor address with the external token.
- `imperFunder_AMOUNT: number`, is the amount of token to be sent to the investor from the impersonificated address. Note that as shares increase in price as the investor buys them you need to account for such increase, I recommend to fund with an amount of 1000.- with an increase of 200.- for each new token, increase is cumulative by order of keys definition. Consider it with no decimals, the decimal normalization is taken care of.

It is important to note that for imperFunder_ADDRESS and imperFunder_AMOUNT you need to consider quantities and prices of block 25464800.

- `address: "0x.."` is the address of the external token.
- `path: ["address", "uint24", "address", "uint24", "address", ...]`, is where the first address is the output token, the last address the input token  and the "unit24" is the fee of the pool between the two adjacent token addresses. Note: you need to follow exactOutput format, so from the out token to the input token.
- `pools: ["0x...", "0x..."]`, the address of pools that are used within the path, following also the same order.

Routes can be used by the frontend to execute swaps.

### USDT Approval

For routing we need to allow `PaymentHub.sol` contract to spend the external token in order to swap it through the Uniswap V3 pool based on path. For any proposed external token it worked fine, but for USDT the `approve` function does not return a boolean as prescribed by the [ERC20 standard](https://eips.ethereum.org/EIPS/eip-20#approve), which makes ethers fail to send and execute the transaction. To address it I tried a workaround within the ethers client but it did not work. To make it function, I added a `INoReturnApprove` interface with a silent `approve` and defined new public function `silentApproveERC20`, this might be a problem since there would need to be a new deployment of the contract for the USDT token. Could be worth to spend more time if it is possible address it client side.

### Packages

I added `@uniswap/v3-core` to the packages to have the `UniswapV3Pool` ABI.

### Small Misecllaneous Changes

Added `.DS_Store` to `.gitignore`. Formatted `PaymentHub.sol`. Added `sepolia` to `KEYS_TEMPALTE.ts` to run tests correctly. Formatted `hardhat.config.ts` and added mainnet fork with fixed block `mainnetForkAtBlock25464800` for routing testings, I did so as tests rely on exchange rates and EOA balances for funding.

### Notes

I omitted testing for unused `withdrawToken` and `multiPay` from `PaymentHub.sol`.